### PR TITLE
Adds GDK_BACKEND enviroment variable to fix some GTK applications

### DIFF
--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -1746,6 +1746,7 @@ pub extern "system" fn execApp<'l>(
         ("WAYLAND_DISPLAY".into(), instance.state.socket.clone()),
         ("QT_QPA_PLATFORM".into(), "wayland".into()),
         ("ELECTRON_OZONE_PLATFORM_HINT".into(), "auto".into()),
+        ("GDK_BACKEND".into(), "wayland".into())
     ];
     instance.xdg.exec_app(app_id, env_vars) as jboolean
 }

--- a/native/src/process.rs
+++ b/native/src/process.rs
@@ -17,8 +17,7 @@ pub fn spawn(
     command
         .env_remove("DISPLAY")
         .env_remove("WAYLAND_DISPLAY")
-        .env_remove("LD_LIBRARY_PATH")
-        .env_remove("GDK_BACKEND");
+        .env_remove("LD_LIBRARY_PATH");
 
     command.envs(env);
 

--- a/native/src/process.rs
+++ b/native/src/process.rs
@@ -17,7 +17,8 @@ pub fn spawn(
     command
         .env_remove("DISPLAY")
         .env_remove("WAYLAND_DISPLAY")
-        .env_remove("LD_LIBRARY_PATH");
+        .env_remove("LD_LIBRARY_PATH")
+        .env_remove("GDK_BACKEND");
 
     command.envs(env);
 


### PR DESCRIPTION
By default, the GDK_BACKEND environment variable was set to "x11", which rendered some GTK applications unlaunchable (for instance, Firefox), since it forced them to launch under the X11 backend that, since Xwayland hasn't been implemented yet, found no X11 server, and refused to launch.

This just adds this variable to the default list when launching executables, with its value set to "wayland", forcing GTK applications to use the Wayland backend.