### PR TITLE
Fix memory leak in WindowFramebuffer

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/render/WindowFramebuffer.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/WindowFramebuffer.java
@@ -144,14 +144,21 @@ public class WindowFramebuffer {
 		GpuBufferSlice alphaUniforms = uniformStorage.writeUniform(new WindowInfoUniform(poseStack.last().pose(), true));
 		GpuBufferSlice opaqueUniforms = uniformStorage.writeUniform(new WindowInfoUniform(poseStack.last().pose(), false));
 		
-		try(RenderPass pass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "window framebuffer", target.getColorTextureView(), OptionalInt.of(0x00000000))) {
-			pass.setPipeline(WINDOW_PIPELINE);
+		try {
+			try(RenderPass pass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "window framebuffer", target.getColorTextureView(), OptionalInt.of(0x00000000))) {
+				pass.setPipeline(WINDOW_PIPELINE);
+				for(CompiledBufferDraw element : elements) {
+					pass.setUniform("window_info", element.alpha ? alphaUniforms : opaqueUniforms);
+					pass.bindTexture("sampler", element.textureView, RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+					pass.setVertexBuffer(0, element.vertexBuffer);
+					pass.setIndexBuffer(element.indexBuffer, element.indexType);
+					pass.drawIndexed(0, 0, element.indexCount, 1);
+				}
+			}
+		}
+		finally {
 			for(CompiledBufferDraw element : elements) {
-				pass.setUniform("window_info", element.alpha ? alphaUniforms : opaqueUniforms);
-				pass.bindTexture("sampler", element.textureView, RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
-				pass.setVertexBuffer(0, element.vertexBuffer);
-				pass.setIndexBuffer(element.indexBuffer, element.indexType);
-				pass.drawIndexed(0, 0, element.indexCount, 1);
+				element.vertexBuffer.close();
 			}
 		}
 	}


### PR DESCRIPTION
I spent entire day with that compositor and then just discovered that it eats ~17GB of RAM. So i went to the code and found the root cause: GPU vertex buffers created each frame didn't release