### PR TITLE
Update `jni` crate to 0.22

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -159,12 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,7 +211,7 @@ dependencies = [
  "btoi",
  "memchr",
  "memmap2",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "xdg",
 ]
@@ -415,7 +409,7 @@ dependencies = [
  "gettext-rs",
  "log",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror",
  "unicase",
  "xdg",
 ]
@@ -534,25 +528,52 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "kurbo"
@@ -911,6 +932,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1065,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,7 +1140,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "wayland-protocols",
  "wayland-protocols-misc",
@@ -1154,31 +1200,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1525,6 +1551,7 @@ dependencies = [
  "resvg",
  "shlex",
  "smithay",
+ "thiserror",
  "xkbcommon 0.8.0",
 ]
 
@@ -1567,20 +1594,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1594,40 +1612,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1637,21 +1634,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1667,21 +1652,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1691,21 +1664,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -9,10 +9,11 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 smithay = { git = "https://github.com/Smithay/smithay.git", rev = "89e58f7", default-features = false, features = [ "wayland_frontend", "backend_drm" ] }
-jni = "0.21.1"
+jni = "0.22.4"
 libc = { version = "0.2.176", default-features = false }
 xkbcommon = "0.8.0"
 cosmic-freedesktop-icons = { git = "https://github.com/pop-os/freedesktop-icons.git", rev = "7a61a70" }
 freedesktop-desktop-entry = "0.8.1"
 resvg = { version = "0.47.0", default-features = false, features = ["text", "memmap-fonts"] }
 shlex = "1.3.0"
+thiserror = "2.0"

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -1,18 +1,15 @@
 #![allow(non_snake_case)]
 
 use crate::egl::{EGLDisplay, EGLHelper};
-use crate::svg::render_svg;
+use crate::java_types::*;
 use crate::utils::get_time;
 use crate::xdg_spec::RawDesktopEntry;
 use crate::{WaylandCraft, wlc_init};
+use jni::objects::{JIntArray, JLongArray, JObjectArray, JPrimitiveArray};
 use jni::{
-    JNIEnv,
-    objects::{JClass, JObject, JString, JValue},
-    signature::{Primitive, ReturnType},
-    sys::{
-        JNI_TRUE, jarray, jboolean, jbyte, jdouble, jint, jlong, jobject,
-        jsize, jstring, jvalue,
-    },
+    Env, bind_java_type,
+    objects::{JClass, JString},
+    sys::{jboolean, jbyte, jdouble, jint, jlong},
 };
 use smithay::{
     backend::allocator::{Buffer, dmabuf::Dmabuf},
@@ -47,6 +44,7 @@ use smithay::{
 };
 use std::ops::DerefMut;
 use std::path::PathBuf;
+use thiserror::Error;
 
 #[allow(clippy::vec_box)]
 pub(crate) struct BridgeState {
@@ -68,77 +66,419 @@ impl BridgeState {
     }
 }
 
-fn jptr_to_instance(ptr: jlong) -> &'static mut WaylandCraft<'static> {
-    let ptr: *mut WaylandCraft = (ptr as usize) as *mut WaylandCraft;
-    unsafe { &mut *ptr }
+fn jptr_to_ref<T>(ptr: jlong) -> Option<&'static T> {
+    let ptr = (ptr as usize) as *const T;
+    if ptr.is_null() {
+        None
+    } else {
+        Some(unsafe { &*ptr })
+    }
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    init")]
-pub extern "system" fn init<'l>(
-    mut env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    proc_addr: jlong,
-    dpy_ptr: jlong,
-) -> jlong {
-    let dpy: EGLDisplay = (dpy_ptr as usize) as EGLDisplay;
-    let egl = EGLHelper::new(dpy, proc_addr as usize);
+fn jptr_to_mut<T>(ptr: jlong) -> Option<&'static mut T> {
+    let ptr = (ptr as usize) as *mut T;
+    if ptr.is_null() {
+        None
+    } else {
+        Some(unsafe { &mut *ptr })
+    }
+}
 
-    let instance = match wlc_init(egl) {
-        Ok(i) => i,
-        Err(err) => {
-            let _ =
-                env.throw_new("java/lang/RuntimeException", err.to_string());
-            return 0;
+bind_java_type! {
+    rust_type = WaylandCraftBridge,
+    java_type = dev.evvie.waylandcraft.bridge.WaylandCraftBridge,
+
+    type_map {
+        WLCSurface => dev.evvie.waylandcraft.bridge.WLCSurface,
+        JRawDesktopEntry => dev.evvie.waylandcraft.desktop.RawDesktopEntry,
+    },
+
+    methods {
+        fn get_or_create_surface(jlong) -> WLCSurface,
+    },
+
+    native_methods {
+        static extern fn init {
+            sig = (glfw_get_proc_address: jlong, egl_display: jlong) -> jlong,
+            fn = init,
+        },
+        static extern fn update {
+            sig = (wlc_bridge_handle: jlong),
+            fn = update,
+        },
+        static extern fn socket {
+            sig = (wlc_bridge_handle: jlong) -> JString,
+            fn = socket,
+        },
+        static extern fn send_frame {
+            sig = (surface_handle: jlong),
+            fn = send_frame,
+        },
+        static extern fn update_surface_data {
+            sig = (wlc_bridge_handle: jlong, surface: WLCSurface),
+            fn = update_surface_data,
+        },
+        static extern fn toplevels {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = toplevels,
+        },
+        static extern fn toplevel_surface {
+            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong) -> jlong,
+            fn = toplevel_surface,
+        },
+        static extern fn toplevel_title {
+            sig = (toplevel_handle: jlong) -> JString,
+            fn = toplevel_title,
+        },
+        static extern fn toplevel_app_id {
+            sig = (toplevel_handle: jlong) -> JString,
+            name = "toplevelAppID",
+            fn = toplevel_app_id,
+        },
+        static extern fn toplevel_resize {
+            sig = (toplevel_handle: jlong, width: jint, height: jint, interactive: jboolean),
+            fn = toplevel_resize,
+        },
+        static extern fn toplevel_resize_ovr {
+            sig = (toplevel_handle: jlong, width: jint, height: jint),
+            fn = toplevel_resize_ovr,
+        },
+        static extern fn minimize_req {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = minimize_req,
+        },
+        static extern fn maximize_req {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = maximize_req,
+        },
+        static extern fn unmaximize_req {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = unmaximize_req,
+        },
+        static extern fn fullscreen_req {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = fullscreen_req,
+        },
+        static extern fn unfullscreen_req {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = unfullscreen_req,
+        },
+        static extern fn move_request {
+            sig = (wlc_bridge_handle: jlong) -> jint[],
+            fn = move_request,
+        },
+        static extern fn resize_request {
+            sig = (wlc_bridge_handle: jlong) -> jint[],
+            fn = resize_request,
+        },
+        static extern fn fullscreened {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = fullscreened,
+        },
+        static extern fn toplevel_maximize {
+            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong),
+            fn = toplevel_maximize,
+        },
+        static extern fn toplevel_fullscreen {
+            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong),
+            fn = toplevel_fullscreen,
+        },
+        static extern fn popups {
+            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            fn = popups,
+        },
+        static extern fn popup_surface {
+            sig = (wlc_bridge_handle: jlong, popup_handle: jlong) -> jlong,
+            fn = popup_surface,
+        },
+        static extern fn popup_parent {
+            sig = (wlc_bridge_handle: jlong, popup_handle: jlong) -> jlong,
+            fn = popup_parent,
+        },
+        static extern fn popup_offset {
+            sig = (popup_handle: jlong) -> jint[],
+            fn = popup_offset,
+        },
+        static extern fn surface_xdg_geometry {
+            sig = (surface_handle: jlong) -> jint[],
+            name = "surfaceXDGGeometry",
+            fn = surface_xdg_geometry,
+        },
+        static extern fn delete_dmabuf {
+            sig = (wlc_bridge_handle: jlong, dmabuf_handle: jlong),
+            fn = delete_dmabuf
+        },
+        extern fn update_surface_tree {
+            sig = (wlc_bridge_handle: jlong, surface: WLCSurface) -> WLCSurface,
+            fn = update_surface_tree,
+        },
+        static extern fn check_input_region {
+            sig = (surface_handle: jlong, x: jdouble, y: jdouble) -> jboolean,
+            fn = check_input_region,
+        },
+        static extern fn pointer_motion {
+            sig = (wlc_bridge_handle: jlong, x: jdouble, y: jdouble),
+            fn = pointer_motion,
+        },
+        static extern fn pointer_motion_focus {
+            sig = (wlc_bridge_handle: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
+            fn = pointer_motion_focus,
+        },
+        static extern fn pointer_rel_motion {
+            sig = (wlc_bridge_handle: jlong, dx: jdouble, dy: jdouble),
+            fn = pointer_rel_motion,
+        },
+        static extern fn maybe_pointer_lock {
+            sig = (wlc_bridge_handle: jlong, surface_handle: jlong) -> jboolean,
+            fn = maybe_pointer_lock,
+        },
+        static extern fn pointer_unlock {
+            sig = (wlc_bridge_handle: jlong),
+            fn = pointer_unlock,
+        },
+        static extern fn pointer_leave {
+            sig = (wlc_bridge_handle: jlong),
+            fn = pointer_leave,
+        },
+        static extern fn pointer_button {
+            sig = (wlc_bridge_handle: jlong, button: jint, state: jint) -> jint,
+            fn = pointer_button,
+        },
+        static extern fn pointer_axis {
+            sig = (wlc_bridge_handle: jlong, axis: jint, value: jdouble),
+            fn = pointer_axis,
+        },
+        static extern fn cursor_shape {
+            sig = (wlc_bridge_handle: jlong) -> jint,
+            fn = cursor_shape,
+        },
+        static extern fn keyboard_focus {
+            sig = (wlc_bridge_handle: jlong, surface_handle: jlong),
+            fn = keyboard_focus,
+        },
+        static extern fn keyboard_activate {
+            sig = (wlc_bridge_handle: jlong),
+            fn = keyboard_activate,
+        },
+        static extern fn keyboard_deactivate {
+            sig = (wlc_bridge_handle: jlong),
+            fn = keyboard_deactivate,
+        },
+        static extern fn keyboard_input {
+            sig = (wlc_bridge_handle: jlong, scancode: jint, action: jint),
+            fn = keyboard_input,
+        },
+        static extern fn keyboard_update {
+            sig = (wlc_bridge_handle: jlong, scancode: jint, pressed: jboolean),
+            fn = keyboard_update,
+        },
+        static extern fn output_size {
+            sig = (wlc_bridge_handle: jlong) -> jint[],
+            fn = output_size,
+        },
+        static extern fn output_bounds {
+            sig = (wlc_bridge_handle: jlong) -> jint[],
+            fn = output_bounds,
+        },
+        static extern fn output_resize {
+            sig = (wlc_bridge_handle: jlong, width: jint, height: jint),
+            fn = output_resize,
+        },
+        static extern fn output_set_bounds {
+            sig = (wlc_bridge_handle: jlong, width: jint, height: jint),
+            fn = output_set_bounds,
+        },
+        static extern fn free_surface {
+            sig = (wlc_bridge_handle: jlong, surface_handle: jlong),
+            fn = free_surface,
+        },
+        static extern fn free_toplevel {
+            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong),
+            fn = free_toplevel,
+        },
+        static extern fn free_popup {
+            sig = (wlc_bridge_handle: jlong, popup_handle: jlong),
+            fn = free_popup,
+        },
+        static extern fn load_desktop_entry {
+            sig = (wlc_bridge_handle: jlong, path: JString) -> JRawDesktopEntry,
+            fn = load_desktop_entry,
+        },
+        static extern fn load_desktop_entries {
+            sig = (wlc_bridge_handle: jlong) -> JRawDesktopEntry[],
+            fn = load_desktop_entries,
+        },
+        static extern fn render_svg {
+            sig = (path: JString, width: jint, height: jint, buffer_ptr: jlong) -> jboolean,
+            name = "renderSVG",
+            fn = render_svg,
+        },
+        static extern fn exec_app {
+            sig = (wlc_bridge_handle: jlong, app_id: JString) -> jboolean,
+            fn = exec_app,
+        },
+        static extern fn set_keymap_default {
+            sig = (wlc_bridge_handle: jlong),
+            fn = set_keymap_default,
+        },
+        static extern fn export_keymap {
+            sig = (wlc_bridge_handle: jlong) -> JString,
+            fn = export_keymap,
+        },
+        static extern fn set_keymap_from_str {
+            sig = (wlc_bridge_handle: jlong, keymap: JString) -> jboolean,
+            fn = set_keymap_from_str,
+        },
+        static extern fn check_dnd_request {
+            sig = (wlc_bridge_handle: jlong) -> jint[],
+            fn = check_dnd_request,
+        },
+        static extern fn check_dnd_active {
+            sig = (wlc_bridge_handle: jlong) -> jboolean,
+            fn = check_dnd_active,
+        },
+        static extern fn dnd_cancel {
+            sig = (wlc_bridge_handle: jlong),
+            fn = dnd_cancel,
+        },
+        static extern fn dnd_drop {
+            sig = (wlc_bridge_handle: jlong),
+            fn = dnd_drop,
+        },
+        static extern fn dnd_motion {
+            sig = (wlc_bridge_handle: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
+            fn = dnd_motion,
+        },
+        static extern fn dnd_icon {
+            sig = (wlc_bridge_handle: jlong) -> jlong,
+            fn = dnd_icon,
+        },
+    },
+}
+
+#[derive(Debug, Error)]
+enum WLCBError {
+    #[error(transparent)]
+    JniError(#[from] jni::errors::Error),
+    #[error(transparent)]
+    Init(Box<dyn std::error::Error>),
+    #[error("{0}")]
+    Null(&'static str),
+    #[error("Null WLC instance handle given. Function: {0}")]
+    NullWlcInstance(&'static str),
+    #[error("Null wayland surface handle given. Function: {0}")]
+    NullWaylandSurface(&'static str),
+    #[error("Null toplevel surface handle given. Function: {0}")]
+    NullToplevelSurface(&'static str),
+    #[error("Null popup surface handle given. Function: {0}")]
+    NullPopupSurface(&'static str),
+    #[error("Error converting OS string, was not UTF8")]
+    OsStringToUtf8,
+    #[error("Unknown pointer button {0} received")]
+    UnknownPointerButton(jint),
+    #[error("Unknown scroll direction {0} received")]
+    UnknownScrollDirection(jint),
+    #[error("Unknown keyboard state {0} received")]
+    UnknownKeyboardState(jint),
+    #[error("Width cannot be below 1")]
+    NonPositiveWidth,
+    #[error("Height cannot be below 1")]
+    NonPositiveHeight,
+}
+
+macro_rules! jptr_to_wlc {
+    ($jptr:expr, $location:literal) => {
+        match jptr_to_mut::<WaylandCraft>($jptr) {
+            None => Err(WLCBError::NullWlcInstance($location)),
+            Some(wlc) => Ok(wlc),
         }
     };
-
-    let instance_box: Box<WaylandCraft> = Box::new(instance);
-    let ptr: *mut WaylandCraft = Box::into_raw(instance_box);
-    let addr: u64 = ptr.addr() as u64;
-    addr as i64
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    update")]
-pub extern "system" fn update<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    instance.update();
+macro_rules! jptr_to_wl_surface {
+    ($jptr:expr, $location:literal) => {
+        match jptr_to_mut::<WlSurface>($jptr) {
+            None => Err(WLCBError::NullWaylandSurface($location)),
+            Some(wl_surface) => Ok(wl_surface),
+        }
+    };
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    socket")]
-pub extern "system" fn socket<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jstring {
-    let instance = jptr_to_instance(ptr);
-    let socket = instance.state.socket.to_str().unwrap();
-    env.new_string(socket).unwrap().into_raw()
+macro_rules! jptr_to_toplevel {
+    ($jptr:expr, $location:literal) => {
+        match jptr_to_mut::<ToplevelSurface>($jptr) {
+            None => Err(WLCBError::NullToplevelSurface($location)),
+            Some(toplevel) => Ok(toplevel),
+        }
+    };
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    sendFrame")]
-pub extern "system" fn sendFrame<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) {
-    let surface =
-        jptr_to_wlsurface(handle).expect("sendFrame wlsurface exists");
+macro_rules! jptr_to_popup {
+    ($jptr:expr, $location:literal) => {
+        match jptr_to_mut::<PopupSurface>($jptr) {
+            None => Err(WLCBError::NullPopupSurface($location)),
+            Some(popup) => Ok(popup),
+        }
+    };
+}
 
-    with_surface_data(&surface, |data| {
+fn init<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    glfw_get_proc_address: jlong,
+    egl_display: jlong,
+) -> Result<jlong, WLCBError> {
+    let dpy: EGLDisplay = (egl_display as usize) as EGLDisplay;
+    let egl = EGLHelper::new(dpy, glfw_get_proc_address as usize);
+
+    let instance = wlc_init(egl).map_err(WLCBError::Init)?;
+    let instance_box = Box::new(instance);
+    let ptr = Box::into_raw(instance_box);
+
+    Ok(ptr.addr() as jlong)
+}
+
+fn update<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    jptr_to_wlc!(wlc_bridge_handle, "update")?.update();
+
+    Ok(())
+}
+
+fn socket<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JString<'local>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "socket")?;
+    let socket = instance
+        .state
+        .socket
+        .to_str()
+        .ok_or(WLCBError::OsStringToUtf8)?;
+
+    Ok(JString::new(env, socket)?)
+}
+
+fn send_frame<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    surface_handle: jlong,
+) -> Result<(), WLCBError> {
+    let surface = jptr_to_wl_surface!(surface_handle, "sendFrame")?;
+
+    with_surface_data(surface, |data| {
         let mut attr_guard = data.cached_state.get::<SurfaceAttributes>();
         let attr = attr_guard.deref_mut().current();
         for c in attr.frame_callbacks.drain(..) {
             c.done(get_time());
         }
     });
+
+    Ok(())
 }
 
 // Get or insert an element and return its handle
@@ -196,14 +536,12 @@ where
     vec.retain(|e| **e != *elem);
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevels")]
-pub extern "system" fn toplevels<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+fn toplevels<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevels")?;
 
     insert_all(
         &mut instance.bridge.toplevels,
@@ -213,19 +551,17 @@ pub extern "system" fn toplevels<'l>(
     instance.bridge.toplevels.retain(|t| t.alive());
 
     let toplevels = get_all_handles(&mut instance.bridge.toplevels);
-    let array = env.new_long_array(toplevels.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &toplevels).unwrap();
-    array.into_raw()
+    let array = JLongArray::new(env, toplevels.len())?;
+    array.set_region(env, 0, &toplevels)?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    popups")]
-pub extern "system" fn popups<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+fn popups<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "popups")?;
 
     insert_all(
         &mut instance.bridge.popups,
@@ -233,197 +569,131 @@ pub extern "system" fn popups<'l>(
     );
 
     instance.bridge.popups.retain(|t| t.alive());
-
     let popups = get_all_handles(&mut instance.bridge.popups);
-    let array = env.new_long_array(popups.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &popups).unwrap();
-    array.into_raw()
+
+    let array = JLongArray::new(env, popups.len())?;
+    array.set_region(env, 0, &popups)?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    minimizeReq")]
-pub extern "system" fn minimizeReq<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+enum RequestsVec {
+    Minimize,
+    Maximize,
+    Unmaximize,
+    Fullscreen,
+    Unfullscreen,
+}
 
-    let handles: Vec<jlong> = instance
-        .state
-        .requests
-        .minimize
+fn clear_requests<'local>(
+    env: &mut Env<'local>,
+    instance: &mut WaylandCraft,
+    vec: RequestsVec,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let vec = match vec {
+        RequestsVec::Minimize => &mut instance.state.requests.minimize,
+        RequestsVec::Maximize => &mut instance.state.requests.maximize,
+        RequestsVec::Unmaximize => &mut instance.state.requests.unmaximize,
+        RequestsVec::Fullscreen => &mut instance.state.requests.fullscreen,
+        RequestsVec::Unfullscreen => &mut instance.state.requests.unfullscreen,
+    };
+
+    let handles: Vec<jlong> = vec
         .iter()
         .filter(|t| t.alive())
         .map(|t| insert_get_handle(&mut instance.bridge.toplevels, t))
         .collect();
 
-    instance.state.requests.minimize.clear();
+    vec.clear();
 
-    let array = env.new_long_array(handles.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &handles).unwrap();
-    array.into_raw()
+    let array = JLongArray::new(env, handles.len())?;
+    array.set_region(env, 0, &handles)?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    maximizeReq")]
-pub extern "system" fn maximizeReq<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
-
-    let handles: Vec<jlong> = instance
-        .state
-        .requests
-        .maximize
-        .iter()
-        .filter(|t| t.alive())
-        .map(|t| insert_get_handle(&mut instance.bridge.toplevels, t))
-        .collect();
-
-    instance.state.requests.maximize.clear();
-
-    let array = env.new_long_array(handles.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &handles).unwrap();
-    array.into_raw()
+fn minimize_req<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "minimizeReq")?;
+    clear_requests(env, instance, RequestsVec::Minimize)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    unmaximizeReq")]
-pub extern "system" fn unmaximizeReq<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
-
-    let handles: Vec<jlong> = instance
-        .state
-        .requests
-        .unmaximize
-        .iter()
-        .filter(|t| t.alive())
-        .map(|t| insert_get_handle(&mut instance.bridge.toplevels, t))
-        .collect();
-
-    instance.state.requests.unmaximize.clear();
-
-    let array = env.new_long_array(handles.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &handles).unwrap();
-    array.into_raw()
+fn maximize_req<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "maximizeReq")?;
+    clear_requests(env, instance, RequestsVec::Maximize)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    fullscreenReq")]
-pub extern "system" fn fullscreenReq<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
-
-    let handles: Vec<jlong> = instance
-        .state
-        .requests
-        .fullscreen
-        .iter()
-        .filter(|t| t.alive())
-        .map(|t| insert_get_handle(&mut instance.bridge.toplevels, t))
-        .collect();
-
-    instance.state.requests.fullscreen.clear();
-
-    let array = env.new_long_array(handles.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &handles).unwrap();
-    array.into_raw()
+fn unmaximize_req<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "unmaximizeReq")?;
+    clear_requests(env, instance, RequestsVec::Unmaximize)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    unfullscreenReq")]
-pub extern "system" fn unfullscreenReq<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
-
-    let handles: Vec<jlong> = instance
-        .state
-        .requests
-        .unfullscreen
-        .iter()
-        .filter(|t| t.alive())
-        .map(|t| insert_get_handle(&mut instance.bridge.toplevels, t))
-        .collect();
-
-    instance.state.requests.unfullscreen.clear();
-
-    let array = env.new_long_array(handles.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &handles).unwrap();
-    array.into_raw()
+fn fullscreen_req<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "fullscreenReq")?;
+    clear_requests(env, instance, RequestsVec::Fullscreen)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    moveRequest")]
-pub extern "system" fn moveRequest<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+fn unfullscreen_req<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "unfullscreenReq")?;
+    clear_requests(env, instance, RequestsVec::Unfullscreen)
+}
+
+fn move_request<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "moveRequest")?;
     let serial = instance.state.requests.move_interactive.pop();
 
     let serial = match serial {
         Some(s) => s,
-        None => return std::ptr::null_mut(),
+        None => return Ok(JPrimitiveArray::null()),
     };
 
-    let serial = Into::<u32>::into(serial) as jint;
-    let array = env.new_int_array(1).unwrap();
-    env.set_int_array_region(&array, 0, &[serial]).unwrap();
-    array.into_raw()
+    let serial = u32::from(serial) as jint;
+
+    let array = JIntArray::new(env, 1)?;
+    array.set_region(env, 0, &[serial])?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    resizeRequest")]
-pub extern "system" fn resizeRequest<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+fn resize_request<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "resizeRequest")?;
     let req = instance.state.requests.resize_interactive.pop();
 
     let (serial, edges) = match req {
         Some(r) => r,
-        None => return std::ptr::null_mut(),
+        None => return Ok(JPrimitiveArray::null()),
     };
 
-    let serial = Into::<u32>::into(serial) as jint;
-    let edges = Into::<u32>::into(edges) as jint;
+    let serial = u32::from(serial) as jint;
+    let edges = u32::from(edges) as jint;
 
-    let array = env.new_int_array(2).unwrap();
-    env.set_int_array_region(&array, 0, &[serial, edges])
-        .unwrap();
-    array.into_raw()
-}
-
-#[allow(non_upper_case_globals)]
-const WLCSurface_class: &str = "dev/evvie/waylandcraft/bridge/WLCSurface";
-
-#[allow(non_upper_case_globals)]
-const WaylandCraftBridge_class: &str =
-    "dev/evvie/waylandcraft/bridge/WaylandCraftBridge";
-
-fn jptr_to_wlsurface(ptr: jlong) -> Option<WlSurface> {
-    if ptr == 0 {
-        return None;
-    }
-    let ptr: *mut WlSurface = (ptr as usize) as *mut WlSurface;
-    let r = unsafe { &mut *ptr };
-    Some(r.clone())
+    let array = JIntArray::new(env, 2)?;
+    array.set_region(env, 0, &[serial, edges])?;
+    Ok(array)
 }
 
 enum BufferAttachResult {
@@ -434,8 +704,8 @@ enum BufferAttachResult {
 
 fn try_attach_shm(
     _instance: &mut WaylandCraft,
-    env: &mut JNIEnv,
-    obj: &JObject,
+    env: &mut Env,
+    jsurface: &WLCSurface,
     buf: &WlBuffer,
     surf_data: &SurfaceData,
 ) -> BufferAttachResult {
@@ -446,23 +716,12 @@ fn try_attach_shm(
         let stride = metadata.stride as jint;
         ensure_viewport_valid(surf_data, Size::new(width, height));
 
-        unsafe {
-            let ptr = ptr.offset(metadata.offset as isize);
-            let jptr = (ptr as usize) as jlong;
-            env.call_method_unchecked(
-                obj,
-                (WLCSurface_class, "attachShmBuffer", "(JIIII)V"),
-                ReturnType::Primitive(Primitive::Void),
-                &[
-                    jvalue { j: jptr },
-                    jvalue { i: width },
-                    jvalue { i: height },
-                    jvalue { i: format },
-                    jvalue { i: stride },
-                ],
-            )
+        let ptr =
+            unsafe { ptr.offset(metadata.offset as isize) }.addr() as jlong;
+
+        jsurface
+            .attach_shm_buffer(env, ptr, width, height, format, stride)
             .unwrap();
-        }
     });
 
     match r {
@@ -476,8 +735,8 @@ fn try_attach_shm(
 
 fn try_attach_single_pixel(
     _instance: &mut WaylandCraft,
-    env: &mut JNIEnv,
-    obj: &JObject,
+    env: &mut Env,
+    jsurface: &WLCSurface,
     buf: &WlBuffer,
     surf_data: &SurfaceData,
 ) -> BufferAttachResult {
@@ -491,29 +750,19 @@ fn try_attach_single_pixel(
     ensure_viewport_valid(surf_data, Size::new(1, 1));
 
     let [r, g, b, a] = pix.rgba8888();
-
-    unsafe {
-        env.call_method_unchecked(
-            obj,
-            (WLCSurface_class, "attachSinglePixelBuffer", "(BBBB)V"),
-            ReturnType::Primitive(Primitive::Void),
-            &[
-                jvalue { b: r as jbyte },
-                jvalue { b: g as jbyte },
-                jvalue { b: b as jbyte },
-                jvalue { b: a as jbyte },
-            ],
+    jsurface
+        .attach_single_pixel_buffer(
+            env, r as jbyte, g as jbyte, b as jbyte, a as jbyte,
         )
         .unwrap();
-    }
 
     BufferAttachResult::Success
 }
 
 fn try_attach_dmabuf(
     instance: &mut WaylandCraft,
-    env: &mut JNIEnv,
-    obj: &JObject,
+    env: &mut Env,
+    jsurface: &WLCSurface,
     buf: &WlBuffer,
     surf_data: &SurfaceData,
 ) -> BufferAttachResult {
@@ -530,17 +779,7 @@ fn try_attach_dmabuf(
     // that a strong reference to the dmabuf is kept.
     let handle = insert_get_handle(&mut instance.bridge.dmabufs, &dmabuf);
 
-    let already_attached = unsafe {
-        env.call_method_unchecked(
-            obj,
-            (WLCSurface_class, "attachDmabuf", "(J)Z"),
-            ReturnType::Primitive(Primitive::Boolean),
-            &[jvalue { j: handle }],
-        )
-        .unwrap()
-        .z()
-        .unwrap()
-    };
+    let already_attached = jsurface.attach_dmabuf(env, handle).unwrap();
 
     if already_attached {
         return BufferAttachResult::Success;
@@ -551,64 +790,43 @@ fn try_attach_dmabuf(
         Err(_) => return BufferAttachResult::Error,
     };
 
-    unsafe {
-        env.call_method_unchecked(
-            obj,
-            (WLCSurface_class, "attachNewDmabuf", "(JJII)V"),
-            ReturnType::Primitive(Primitive::Void),
-            &[
-                jvalue { j: handle },
-                jvalue {
-                    j: (image as usize) as jlong,
-                },
-                jvalue { i: width },
-                jvalue { i: height },
-            ],
-        )
+    jsurface
+        .attach_new_dmabuf(env, handle, image.addr() as jlong, width, height)
         .unwrap();
-    }
 
     BufferAttachResult::Success
 }
 
-fn jptr_to_dmabuf(ptr: jlong) -> Option<&'static Dmabuf> {
-    if ptr == 0 {
-        return None;
-    }
-    let ptr: *mut Dmabuf = (ptr as usize) as *mut Dmabuf;
-    let r = unsafe { &mut *ptr };
-    Some(r)
-}
-
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    deleteDmabuf")]
-pub extern "system" fn delete_dmabuf<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    let dmabuf = match jptr_to_dmabuf(handle) {
-        Some(d) => d,
-        None => return,
-    };
+fn delete_dmabuf<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    dmabuf_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "deleteDmabuf")?;
+    let dmabuf = jptr_to_ref::<Dmabuf>(dmabuf_handle).ok_or_else(|| {
+        WLCBError::Null(
+            "deleteDmabuf: dmabuf does not exist",
+        )
+    })?;
 
     instance.bridge.dmabufs.retain(|d| **d != *dmabuf);
+
+    Ok(())
 }
 
 // Proxy to call the try_attach_* family of functions
 fn try_attach_buffer(
     instance: &mut WaylandCraft,
-    env: &mut JNIEnv,
-    obj: &JObject,
+    env: &mut Env,
+    jsurface: &WLCSurface,
     buf: &WlBuffer,
     surf_data: &SurfaceData,
 ) -> Result<(), ()> {
     type TryAttachFn = fn(
         instance: &mut WaylandCraft,
-        env: &mut JNIEnv,
-        obj: &JObject,
+        env: &mut Env,
+        jsurface: &WLCSurface,
         buf: &WlBuffer,
         surf_data: &SurfaceData,
     ) -> BufferAttachResult;
@@ -616,7 +834,7 @@ fn try_attach_buffer(
     let funcs: [TryAttachFn; 3] =
         [try_attach_shm, try_attach_single_pixel, try_attach_dmabuf];
     for func in funcs {
-        let result = func(instance, env, obj, buf, surf_data);
+        let result = func(instance, env, jsurface, buf, surf_data);
         match result {
             BufferAttachResult::NotManaged => continue,
             BufferAttachResult::Success => return Ok(()),
@@ -627,29 +845,20 @@ fn try_attach_buffer(
     unreachable!("Buffer did not match any attachment mechanism!")
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    updateSurfaceData")]
-pub extern "system" fn updateSurfaceData<'l>(
-    mut env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    obj: JObject<'l>,
-) {
-    let instance = jptr_to_instance(ptr);
-    let handle: jlong = env
-        .get_field_unchecked(
-            &obj,
-            (WLCSurface_class, "handle", "J"),
-            ReturnType::Primitive(Primitive::Long),
-        )
-        .unwrap()
-        .j()
-        .unwrap();
+fn update_surface_data<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    jsurface: WLCSurface<'local>,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "updateSurfaceData")?;
 
-    let surface = match jptr_to_wlsurface(handle) {
-        Some(s) => s,
-        None => return,
-    };
+    let handle = jsurface.handle(env)?;
+    let surface = jptr_to_ref::<WlSurface>(handle).ok_or_else(|| {
+        WLCBError::Null(
+            "updateSufaceData: WLCSurface.handle() returned a null pointer",
+        )
+    })?;
 
     with_states(&surface, |data| {
         let mut attr_guard = data.cached_state.get::<SurfaceAttributes>();
@@ -665,7 +874,7 @@ pub extern "system" fn updateSurfaceData<'l>(
         };
 
         if let Some(buf) = maybe_buf {
-            let r = try_attach_buffer(instance, &mut env, &obj, buf, data);
+            let r = try_attach_buffer(instance, env, &jsurface, buf, data);
             if r.is_err() {
                 eprintln!("Buffer attach failed!");
                 remove_buf = true;
@@ -677,130 +886,92 @@ pub extern "system" fn updateSurfaceData<'l>(
         }
 
         if remove_buf {
-            unsafe {
-                env.call_method_unchecked(
-                    &obj,
-                    (WLCSurface_class, "removeBuffer", "()V"),
-                    ReturnType::Primitive(Primitive::Void),
-                    &[],
-                )
-                .unwrap();
-            }
+            jsurface.remove_buffer(env).unwrap();
         }
 
         let mut vp_data_guard = data.cached_state.get::<ViewportCachedState>();
         let vp_data = vp_data_guard.deref_mut().current();
 
         if let Some(src) = vp_data.src {
-            unsafe {
-                env.call_method_unchecked(
-                    &obj,
-                    (WLCSurface_class, "setViewportSrc", "(DDDD)V"),
-                    ReturnType::Primitive(Primitive::Void),
-                    &[
-                        jvalue { d: src.loc.x },
-                        jvalue { d: src.loc.y },
-                        jvalue { d: src.size.w },
-                        jvalue { d: src.size.h },
-                    ],
+            jsurface
+                .set_viewport_src(
+                    env, src.loc.x, src.loc.y, src.size.w, src.size.h,
                 )
                 .unwrap();
-            }
         }
 
         if let Some(dst) = vp_data.dst {
-            unsafe {
-                env.call_method_unchecked(
-                    &obj,
-                    (WLCSurface_class, "setViewportDst", "(II)V"),
-                    ReturnType::Primitive(Primitive::Void),
-                    &[jvalue { i: dst.w }, jvalue { i: dst.h }],
-                )
-                .unwrap();
-            }
+            jsurface.set_viewport_dst(env, dst.w, dst.h).unwrap();
         }
     });
+
+    Ok(())
 }
 
-fn jptr_to_toplevel(ptr: jlong) -> &'static mut ToplevelSurface {
-    let ptr: *mut ToplevelSurface = (ptr as usize) as *mut ToplevelSurface;
-    unsafe { &mut *ptr }
+fn toplevel_surface<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    toplevel_handle: jlong,
+) -> Result<jlong, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevelSurface")?;
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelSurface")?;
+
+    let surface = toplevel.wl_surface();
+
+    Ok(insert_get_handle(&mut instance.bridge.surfaces, surface))
 }
 
-fn jptr_to_popup(ptr: jlong) -> &'static mut PopupSurface {
-    let ptr: *mut PopupSurface = (ptr as usize) as *mut PopupSurface;
-    unsafe { &mut *ptr }
+fn popup_surface<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    popup_handle: jlong,
+) -> Result<jlong, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "popupSurface")?;
+    let popup = jptr_to_popup!(popup_handle, "popupSurface")?;
+
+    let surface = popup.wl_surface();
+
+    Ok(insert_get_handle(&mut instance.bridge.surfaces, surface))
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelSurface")]
-pub extern "system" fn toplevelSurface<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) -> jlong {
-    let instance = jptr_to_instance(ptr);
-    let toplevel: &mut ToplevelSurface = jptr_to_toplevel(handle);
-    let surface: &WlSurface = toplevel.wl_surface();
+fn popup_parent<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    popup_handle: jlong,
+) -> Result<jlong, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "popupParent")?;
+    let popup = jptr_to_popup!(popup_handle, "popupParent")?;
 
-    insert_get_handle(&mut instance.bridge.surfaces, surface)
-}
-
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    popupSurface")]
-pub extern "system" fn popupSurface<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) -> jlong {
-    let instance = jptr_to_instance(ptr);
-    let popup: &mut PopupSurface = jptr_to_popup(handle);
-    let surface: &WlSurface = popup.wl_surface();
-
-    insert_get_handle(&mut instance.bridge.surfaces, surface)
-}
-
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    popupParent")]
-pub extern "system" fn popupParent<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) -> jlong {
-    let instance = jptr_to_instance(ptr);
-    let popup: &mut PopupSurface = jptr_to_popup(handle);
-    let parent_surface: Option<WlSurface> = popup.get_parent_surface();
-    if parent_surface.is_none() {
-        return 0;
-    }
-    let parent_surface: WlSurface = parent_surface.unwrap();
+    let parent_surface = match popup.get_parent_surface() {
+        None => return Ok(0),
+        Some(parent_surface) => parent_surface,
+    };
 
     for toplevel in &instance.bridge.toplevels {
         if *toplevel.wl_surface() == parent_surface {
-            return get_handle(&instance.bridge.toplevels, toplevel);
+            return Ok(get_handle(&instance.bridge.toplevels, toplevel));
         }
     }
 
     for popup in &instance.bridge.popups {
         if *popup.wl_surface() == parent_surface {
-            return get_handle(&instance.bridge.popups, popup);
+            return Ok(get_handle(&instance.bridge.popups, popup));
         }
     }
 
-    0
+    Ok(0)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    popupOffset")]
-pub extern "system" fn popupOffset<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) -> jarray {
-    let popup: &mut PopupSurface = jptr_to_popup(handle);
+fn popup_offset<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    popup_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let popup = jptr_to_popup!(popup_handle, "popupOffset")?;
+
     let mut offset: [jint; 2] = [0, 0];
 
     popup.with_cached_state(|state| {
@@ -812,65 +983,27 @@ pub extern "system" fn popupOffset<'l>(
         }
     });
 
-    let array = env.new_int_array(2).unwrap();
-    env.set_int_array_region(&array, 0, &offset).unwrap();
-    array.into_raw()
+    let array = JIntArray::new(env, 2)?;
+    array.set_region(env, 0, &offset)?;
+    Ok(array)
 }
 
-fn get_or_create_surface<'l>(
-    env: &mut JNIEnv<'l>,
-    state: &mut BridgeState,
-    bridge_obj: &JObject<'l>,
-    surface: &WlSurface,
-) -> JObject<'l> {
-    let handle = insert_get_handle(&mut state.surfaces, surface);
-    let sig = "(J)Ldev/evvie/waylandcraft/bridge/WLCSurface;";
-    unsafe {
-        env.call_method_unchecked(
-            bridge_obj,
-            (WaylandCraftBridge_class, "getOrCreateSurface", sig),
-            ReturnType::Object,
-            &[jvalue { j: handle }],
+fn update_surface_tree<'local>(
+    env: &mut Env<'local>,
+    this: WaylandCraftBridge<'local>,
+    wlc_bridge_handle: jlong,
+    surface: WLCSurface<'local>,
+) -> Result<WLCSurface<'local>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "updateSurfaceTrees")?;
+
+    let handle = surface.handle(env)?;
+    let surface = jptr_to_ref::<WlSurface>(handle).ok_or_else(|| {
+        WLCBError::Null(
+            "updateSufaceTree: WLCSurface.handle() returned a null pointer",
         )
-        .unwrap()
-        .l()
-        .unwrap()
-    }
-}
+    })?;
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    updateSurfaceTree")]
-pub extern "system" fn updateSurfaceTree<'l>(
-    mut env: JNIEnv<'l>,
-    bridge_obj: JObject<'l>,
-    root: JObject<'l>,
-) -> jobject {
-    let instance_ptr: jlong = env
-        .get_field_unchecked(
-            &bridge_obj,
-            (WaylandCraftBridge_class, "instance", "J"),
-            ReturnType::Primitive(Primitive::Long),
-        )
-        .unwrap()
-        .j()
-        .unwrap();
-
-    let instance = jptr_to_instance(instance_ptr);
-
-    let handle: jlong = env
-        .get_field_unchecked(
-            &root,
-            (WLCSurface_class, "handle", "J"),
-            ReturnType::Primitive(Primitive::Long),
-        )
-        .unwrap()
-        .j()
-        .unwrap();
-
-    let surface =
-        jptr_to_wlsurface(handle).expect("updateSurfaceTree surface alive");
-
-    let mut last_child: JObject = JObject::null();
+    let mut last_child = WLCSurface::null();
 
     with_surface_tree_upward(
         &surface,
@@ -879,12 +1012,9 @@ pub extern "system" fn updateSurfaceTree<'l>(
             TraversalAction::DoChildren(Some(surface.clone()))
         },
         |surface, data, parent| {
-            let obj = get_or_create_surface(
-                &mut env,
-                &mut instance.bridge,
-                &bridge_obj,
-                surface,
-            );
+            let handle =
+                insert_get_handle(&mut instance.bridge.surfaces, surface);
+            let surface = this.get_or_create_surface(env, handle).unwrap();
 
             // Set the WLCSurface parentHandle
             let parent_handle = if let Some(p) = parent {
@@ -892,58 +1022,22 @@ pub extern "system" fn updateSurfaceTree<'l>(
             } else {
                 0
             };
-            env.set_field_unchecked(
-                &obj,
-                (WLCSurface_class, "parentHandle", "J"),
-                JValue::Long(parent_handle),
-            )
-            .unwrap();
+
+            surface.set_parent_handle(env, parent_handle).unwrap();
 
             // Set last child to point to this current surface
-            if !last_child.as_raw().is_null() {
-                env.set_field_unchecked(
-                    &last_child,
-                    (
-                        WLCSurface_class,
-                        "nextChild",
-                        "Ldev/evvie/waylandcraft/bridge/WLCSurface;",
-                    ),
-                    JValue::Object(&obj),
-                )
-                .unwrap();
+            if !last_child.is_null() {
+                last_child.set_next_child(env, &surface).unwrap();
             }
 
             // Set this surfaces nextChild to null
-            env.set_field_unchecked(
-                &obj,
-                (
-                    WLCSurface_class,
-                    "nextChild",
-                    "Ldev/evvie/waylandcraft/bridge/WLCSurface;",
-                ),
-                JValue::Object(&JObject::null()),
-            )
-            .unwrap();
+            surface.set_next_child(env, WLCSurface::null()).unwrap();
 
             // Set this surfaces prevChild to the last child
-            env.set_field_unchecked(
-                &obj,
-                (
-                    WLCSurface_class,
-                    "prevChild",
-                    "Ldev/evvie/waylandcraft/bridge/WLCSurface;",
-                ),
-                JValue::Object(&last_child),
-            )
-            .unwrap();
+            surface.set_prev_child(env, &last_child).unwrap();
 
             // Mark this surface as visited
-            env.set_field_unchecked(
-                &obj,
-                (WLCSurface_class, "visited", "Z"),
-                JValue::Bool(1),
-            )
-            .unwrap();
+            surface.set_visited(env, true).unwrap();
 
             // Set subsurface location
             let (sx, sy) = if data.cached_state.has::<SubsurfaceCachedState>() {
@@ -955,184 +1049,157 @@ pub extern "system" fn updateSurfaceTree<'l>(
                 (0, 0)
             };
 
-            env.set_field_unchecked(
-                &obj,
-                (WLCSurface_class, "xoff", "I"),
-                JValue::Int(sx),
-            )
-            .unwrap();
+            surface.set_xoff(env, sx).unwrap();
+            surface.set_yoff(env, sy).unwrap();
 
-            env.set_field_unchecked(
-                &obj,
-                (WLCSurface_class, "yoff", "I"),
-                JValue::Int(sy),
-            )
-            .unwrap();
-
-            last_child = obj;
+            last_child = surface;
         },
         |_surface, _data, _parent| true,
     );
 
-    last_child.into_raw()
+    Ok(last_child)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerMotion")]
-pub extern "system" fn pointerMotion<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
+fn pointer_motion<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     x: jdouble,
     y: jdouble,
-) {
-    let instance = jptr_to_instance(ptr);
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerMotion")?;
     instance.state.seat.pointer_motion(x, y);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerMotionFocus")]
-pub extern "system" fn pointerMotionFocus<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
+fn pointer_motion_focus<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    surface_handle: jlong,
     x: jdouble,
     y: jdouble,
-) {
-    let instance = jptr_to_instance(ptr);
-    let surface = jptr_to_wlsurface(handle);
-
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerMotionFocus")?;
+    let surface = jptr_to_ref(surface_handle);
     instance.state.seat.pointer_motion_focus(surface, x, y);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerRelMotion")]
-pub extern "system" fn pointerRelMotion<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
+fn pointer_rel_motion<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     dx: jdouble,
     dy: jdouble,
-) {
-    let instance = jptr_to_instance(ptr);
-
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerRelMotion")?;
     instance.state.seat.pointer_relative_motion(dx, dy);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    maybePointerLock")]
-pub extern "system" fn maybePointerLock<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) -> jboolean {
-    let instance = jptr_to_instance(ptr);
-    let surface = match jptr_to_wlsurface(handle) {
-        Some(s) => s,
-        None => return 0,
+fn maybe_pointer_lock<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    surface_handle: jlong,
+) -> Result<jboolean, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "maybePointerLock")?;
+    let Some(surface) = jptr_to_ref(surface_handle) else {
+        return Ok(false);
     };
 
-    instance.state.seat.pointer_lock(&surface) as jboolean
+    Ok(instance.state.seat.pointer_lock(&surface))
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerUnlock")]
-pub extern "system" fn pointerUnlock<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn pointer_unlock<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerUnlock")?;
+    instance.state.seat.pointer_unlock();
 
-    instance.state.seat.pointer_unlock()
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerLeave")]
-pub extern "system" fn pointerLeave<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn pointer_leave<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerLeave")?;
     instance.state.seat.pointer_motion_focus(None, 0.0, 0.0);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerButton")]
-pub extern "system" fn pointerButton<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
+fn pointer_button<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     button: jint,
     state: jint,
-) -> jint {
-    let instance = jptr_to_instance(ptr);
+) -> Result<jint, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerButton")?;
 
     let state = match state {
         0 => ButtonState::Released,
         1 => ButtonState::Pressed,
-        _ => unreachable!(),
+        _ => return Err(WLCBError::UnknownPointerButton(state)),
     };
 
-    instance.state.seat.pointer_button(button as u32, state) as jint
+    Ok(instance.state.seat.pointer_button(button as u32, state) as jint)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    pointerAxis")]
-pub extern "system" fn pointerAxis<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
+fn pointer_axis<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     axis: jint,
     value: jdouble,
-) {
-    let instance = jptr_to_instance(ptr);
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerAxis")?;
 
     let axis = match axis {
         0 => Axis::VerticalScroll,
         1 => Axis::HorizontalScroll,
         _ => {
-            return;
+            return Err(WLCBError::UnknownScrollDirection(axis));
         }
     };
 
-    instance.state.seat.pointer_axis(axis, value);
+    Ok(instance.state.seat.pointer_axis(axis, value))
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    cursorShape")]
-pub extern "system" fn cursorShape<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jint {
-    let instance = jptr_to_instance(ptr);
+fn cursor_shape<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<jint, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "cursorShape")?;
 
-    match instance.state.seat.cursor_shape {
+    let shape = match instance.state.seat.cursor_shape {
         Some(shape) => shape as jint,
         None => -1,
-    }
-}
-
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    keyboardFocus")]
-pub extern "system" fn keyboardFocus<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    let toplevel: Option<ToplevelSurface> = if handle != 0 {
-        Some(jptr_to_toplevel(handle).clone())
-    } else {
-        None
     };
 
-    let surface = toplevel.as_ref().map(|t| t.wl_surface().clone());
+    Ok(shape)
+}
+
+fn keyboard_focus<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    surface_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardFocus")?;
+    let toplevel: Option<&ToplevelSurface> = jptr_to_ref(surface_handle);
+
+    let surface = toplevel.map(|t| t.wl_surface().clone());
 
     // Update the client gaining keyboard focus with the clipboard contents
     let client = surface.as_ref().and_then(|s| s.client());
@@ -1168,77 +1235,77 @@ pub extern "system" fn keyboardFocus<'l>(
         .for_each(|t| {
             t.send_pending_configure();
         });
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    keyboardActivate")]
-pub extern "system" fn keyboardActivate<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn keyboard_activate<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardActivate")?;
     instance.state.seat.activate_keyboard();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    keyboardDeactivate")]
-pub extern "system" fn keyboardDeactivate<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn keyboard_deactivate<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardDeactivate")?;
     instance.state.seat.deactivate_keyboard();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    keyboardInput")]
-pub extern "system" fn keyboardInput<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
+fn keyboard_input<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     scancode: jint,
     action: jint,
-) {
-    let instance = jptr_to_instance(ptr);
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardInput")?;
 
     let scancode = scancode as u32;
     let action = match action {
         0 => KeyState::Released,
         1 => KeyState::Pressed,
         _ => {
-            return;
+            return Err(WLCBError::UnknownKeyboardState(action));
         }
     };
 
     instance.state.seat.keyboard_key(scancode, action);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    keyboardUpdate")]
-pub extern "system" fn keyboardUpdate<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
+fn keyboard_update<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     scancode: jint,
-    press: jboolean,
-) {
-    let instance = jptr_to_instance(ptr);
+    pressed: jboolean,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardUpdate")?;
     instance
         .state
         .seat
-        .keyboard_update_xkb(scancode as u32, press == JNI_TRUE);
+        .keyboard_update_xkb(scancode as u32, pressed);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    fullscreened")]
-pub extern "system" fn fullscreened<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+fn fullscreened<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "fullscreened")?;
 
     let mut handles: Vec<jlong> = vec![];
     for toplevel in instance.state.xdg_state.toplevel_surfaces() {
@@ -1247,143 +1314,138 @@ pub extern "system" fn fullscreened<'l>(
                 .map(|s| s.states.contains(xdg_toplevel::State::Fullscreen))
                 .unwrap_or(false)
         });
+
         if !fullscreen {
             continue;
         }
 
-        let handle =
-            insert_get_handle(&mut instance.bridge.toplevels, toplevel);
-        handles.push(handle);
+        handles
+            .push(insert_get_handle(&mut instance.bridge.toplevels, toplevel));
     }
 
-    let array = env.new_long_array(handles.len() as jsize).unwrap();
-    env.set_long_array_region(&array, 0, &handles).unwrap();
-    array.into_raw()
+    let array = JLongArray::new(env, handles.len())?;
+    array.set_region(env, 0, &handles)?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    outputSize")]
-pub extern "system" fn outputSize<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(handle);
+fn output_size<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputSize")?;
 
     let size = instance.state.output.size();
     let size: [jint; 2] = [size.w, size.h];
 
-    let array = env.new_int_array(2).unwrap();
-    env.set_int_array_region(&array, 0, &size).unwrap();
-    array.into_raw()
+    let array = JIntArray::new(env, 2)?;
+    array.set_region(env, 0, &size)?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    outputBounds")]
-pub extern "system" fn outputBounds<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(handle);
+fn output_bounds<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputBounds")?;
 
     let bounds = instance.state.output.bounds();
     let bounds: [jint; 2] = [bounds.w, bounds.h];
 
-    let array = env.new_int_array(2).unwrap();
-    env.set_int_array_region(&array, 0, &bounds).unwrap();
-    array.into_raw()
+    let array = JIntArray::new(env, 2)?;
+    array.set_region(env, 0, &bounds)?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    outputResize")]
-pub extern "system" fn outputResize<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
+fn output_resize<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     width: jint,
     height: jint,
-) {
-    let instance = jptr_to_instance(handle);
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputResize")?;
     let size = instance.state.output.size();
     let width_changed = size.w != width;
     let height_changed = size.h != height;
 
-    if width <= 0 || height <= 0 {
-        return;
+    if width < 1 {
+        return Err(WLCBError::NonPositiveWidth);
+    } else if height < 1 {
+        return Err(WLCBError::NonPositiveHeight);
     }
 
     if !width_changed && !height_changed {
-        return;
+        return Ok(());
     }
 
     instance.state.output.resize(width, height);
 
     for toplevel in instance.state.xdg_state.toplevel_surfaces() {
         toplevel.with_pending_state(|state| {
-            let fullscreen =
-                state.states.contains(xdg_toplevel::State::Fullscreen);
-            if fullscreen {
+            if state.states.contains(xdg_toplevel::State::Fullscreen) {
                 state.size = Some(Size::new(width, height));
             }
         });
+
         toplevel.send_pending_configure();
     }
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    outputSetBounds")]
-pub extern "system" fn outputSetBounds<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
+fn output_set_bounds<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
     width: jint,
     height: jint,
-) {
-    let instance = jptr_to_instance(handle);
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputSetBounds")?;
     let bounds = instance.state.output.bounds();
     let width_changed = bounds.w != width;
     let height_changed = bounds.h != height;
 
-    if width <= 0 || height <= 0 {
-        return;
+    if width < 1 {
+        return Err(WLCBError::NonPositiveWidth);
+    } else if height < 1 {
+        return Err(WLCBError::NonPositiveHeight);
     }
 
     if !width_changed && !height_changed {
-        return;
+        return Ok(());
     }
 
     instance.state.output.set_bounds(width, height);
 
     for toplevel in instance.state.xdg_state.toplevel_surfaces() {
         toplevel.with_pending_state(|state| {
-            let maximized =
-                state.states.contains(xdg_toplevel::State::Maximized);
-            if maximized {
+            if state.states.contains(xdg_toplevel::State::Maximized) {
                 state.size = Some(Size::new(width, height));
             }
         });
+
         toplevel.send_pending_configure();
     }
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    checkInputRegion")]
-pub extern "system" fn checkInputRegion<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
+fn check_input_region<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    surface_handle: jlong,
     x: jdouble,
     y: jdouble,
-) -> jboolean {
-    let surface = match jptr_to_wlsurface(handle) {
-        Some(s) => s,
-        None => return 0,
+) -> Result<jboolean, WLCBError> {
+    let Some(surface) = jptr_to_ref(surface_handle) else {
+        return Ok(false);
     };
 
     let point: Point<f64, Logical> = Point::new(x, y);
 
-    with_states(&surface, |data| {
+    Ok(with_states(&surface, |data| {
         let mut attr_guard = data.cached_state.get::<SurfaceAttributes>();
         let attr = attr_guard.deref_mut().current();
         if let Some(r) = &attr.input_region {
@@ -1391,19 +1453,17 @@ pub extern "system" fn checkInputRegion<'l>(
         } else {
             true
         }
-    }) as jboolean
+    }))
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    surfaceXDGGeometry")]
-pub extern "system" fn surfaceXDGGeometry<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) -> jarray {
-    let surface = match jptr_to_wlsurface(handle) {
+fn surface_xdg_geometry<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    surface_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let surface = match jptr_to_ref(surface_handle) {
         Some(s) => s,
-        None => return std::ptr::null_mut(),
+        None => return Ok(JIntArray::null()),
     };
 
     let geometry: Option<[jint; 4]> = with_states(&surface, |states| {
@@ -1415,22 +1475,21 @@ pub extern "system" fn surfaceXDGGeometry<'l>(
     });
 
     if let Some(geometry) = geometry {
-        let array = env.new_int_array(4).unwrap();
-        env.set_int_array_region(&array, 0, &geometry).unwrap();
-        array.into_raw()
+        let array = JIntArray::new(env, 4)?;
+        array.set_region(env, 0, &geometry)?;
+        Ok(array)
     } else {
-        std::ptr::null_mut()
+        Ok(JIntArray::null())
     }
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelTitle")]
-pub extern "system" fn toplevelTitle<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) -> jstring {
-    let toplevel = jptr_to_toplevel(handle);
+fn toplevel_title<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    toplevel_handle: jlong,
+) -> Result<JString<'local>, WLCBError> {
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelTitle")?;
+
     let surface = toplevel.wl_surface();
 
     let title = with_states(surface, |states| {
@@ -1440,24 +1499,24 @@ pub extern "system" fn toplevelTitle<'l>(
             .unwrap()
             .lock()
             .unwrap();
+
         attr_guard.title.clone()
     });
 
     if let Some(title) = title {
-        env.new_string(&title).unwrap().into_raw()
+        Ok(env.new_string(title)?)
     } else {
-        std::ptr::null_mut()
+        Ok(JString::null())
     }
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelAppID")]
-pub extern "system" fn toplevelAppID<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
-) -> jstring {
-    let toplevel = jptr_to_toplevel(handle);
+fn toplevel_app_id<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    toplevel_handle: jlong,
+) -> Result<JString<'local>, WLCBError> {
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelAppId")?;
+
     let surface = toplevel.wl_surface();
 
     let app_id = with_states(surface, |states| {
@@ -1467,69 +1526,70 @@ pub extern "system" fn toplevelAppID<'l>(
             .unwrap()
             .lock()
             .unwrap();
+
         attr_guard.app_id.clone()
     });
 
     if let Some(app_id) = app_id {
-        env.new_string(&app_id).unwrap().into_raw()
+        Ok(env.new_string(app_id)?)
     } else {
-        std::ptr::null_mut()
+        Ok(JString::null())
     }
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelResize")]
-pub extern "system" fn toplevelResize<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
+fn toplevel_resize<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    toplevel_handle: jlong,
     width: jint,
     height: jint,
     interactive: jboolean,
-) {
-    let toplevel = jptr_to_toplevel(handle);
+) -> Result<(), WLCBError> {
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelResize")?;
 
     toplevel.with_pending_state(|state| {
         state.size = Some(Size::new(width, height));
         state.states.unset(xdg_toplevel::State::Maximized);
         state.states.unset(xdg_toplevel::State::Fullscreen);
-        if interactive == JNI_TRUE {
+        if interactive {
             state.states.set(xdg_toplevel::State::Resizing);
         } else {
             state.states.unset(xdg_toplevel::State::Resizing);
         }
     });
+
     toplevel.send_pending_configure();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelResizeOvr")]
-pub extern "system" fn toplevelResizeOvr<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    handle: jlong,
+fn toplevel_resize_ovr<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    toplevel_handle: jlong,
     width: jint,
     height: jint,
-) {
-    let toplevel = jptr_to_toplevel(handle);
+) -> Result<(), WLCBError> {
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelResizeOvr")?;
 
     toplevel.with_pending_state(|state| {
         state.size = Some(Size::new(width, height));
         state.states.unset(xdg_toplevel::State::Resizing);
     });
+
     toplevel.send_pending_configure();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelMaximize")]
-pub extern "system" fn toplevelMaximize<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    let toplevel = jptr_to_toplevel(handle);
+fn toplevel_maximize<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    toplevel_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevelMaximize")?;
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelMaximize")?;
 
     toplevel.with_pending_state(|state| {
         if state.states.contains(xdg_toplevel::State::Fullscreen) {
@@ -1539,242 +1599,193 @@ pub extern "system" fn toplevelMaximize<'l>(
         state.size = Some(output.bounds());
         state.states.set(xdg_toplevel::State::Maximized);
     });
+
     toplevel.send_configure();
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    toplevelFullscreen")]
-pub extern "system" fn toplevelFullscreen<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    let toplevel = jptr_to_toplevel(handle);
+fn toplevel_fullscreen<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    toplevel_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevelFullscreen")?;
+    let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelFullscreen")?;
 
     toplevel.with_pending_state(|state| {
         let output = &instance.state.output;
         state.size = Some(output.size());
         state.states.set(xdg_toplevel::State::Fullscreen);
     });
+
     toplevel.send_configure();
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    freeSurface")]
-pub extern "system" fn freeSurface<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    remove_element(&mut instance.bridge.surfaces, handle);
+fn free_surface<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    surface_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "freeSurface")?;
+    remove_element(&mut instance.bridge.surfaces, surface_handle);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    freeToplevel")]
-pub extern "system" fn freeToplevel<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    remove_element(&mut instance.bridge.toplevels, handle);
+fn free_toplevel<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    toplevel_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "freeToplevel")?;
+    remove_element(&mut instance.bridge.toplevels, toplevel_handle);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    freePopup")]
-pub extern "system" fn freePopup<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
-    remove_element(&mut instance.bridge.popups, handle);
+fn free_popup<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    popup_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "freePopup")?;
+    remove_element(&mut instance.bridge.popups, popup_handle);
+
+    Ok(())
 }
 
-#[allow(non_upper_case_globals)]
-const RawDesktopEntry_class: &str =
-    "dev/evvie/waylandcraft/desktop/RawDesktopEntry";
-
-fn raw_desktop_entry_to_java<'l>(
-    env: &mut JNIEnv<'l>,
+fn raw_desktop_entry_to_java<'local>(
+    env: &mut Env<'local>,
     entry: &RawDesktopEntry,
-) -> JObject<'l> {
-    macro_rules! to_jstr {
-        ($s:expr) => {
-            env.new_string($s).unwrap()
-        };
-    }
-    macro_rules! nullstr {
-        () => {
-            unsafe { JString::from_raw(std::ptr::null_mut()) }
-        };
-    }
-    macro_rules! to_jstr_opt {
-        ($s:expr) => {
-            match $s {
-                Some(s) => to_jstr!(s),
-                None => nullstr!(),
+) -> Result<JRawDesktopEntry<'local>, WLCBError> {
+    macro_rules! opt_to_jstring {
+        ($env:expr, $string:expr) => {
+            match $string {
+                Some(string) => JString::new($env, string),
+                None => Ok(JString::null()),
             }
         };
     }
 
-    let app_id: JString<'l> = to_jstr!(&entry.app_id);
-    let name: JString<'l> = to_jstr_opt!(&entry.name);
-    let generic_name: JString<'l> = to_jstr_opt!(&entry.generic_name);
-    let exec: JString<'l> = to_jstr_opt!(&entry.exec);
-    let exec_terminal: jboolean = entry.exec_terminal as jboolean;
-    let comment: JString<'l> = to_jstr_opt!(&entry.comment);
-    let visible: jboolean = entry.visible as jboolean;
-    let icon_path: JString<'l> = to_jstr_opt!(&entry.icon_path);
+    let app_id = JString::new(env, &entry.app_id)?;
+    let name = opt_to_jstring!(env, &entry.name)?;
+    let generic_name = opt_to_jstring!(env, &entry.generic_name)?;
+    let exec = opt_to_jstring!(env, &entry.exec)?;
+    let exec_terminal = entry.exec_terminal;
+    let comment = opt_to_jstring!(env, &entry.comment)?;
+    let visible = entry.visible;
+    let icon_path = opt_to_jstring!(env, &entry.icon_path)?;
 
-    let keywords: Vec<JString<'l>> =
-        entry.keywords.iter().map(|k| to_jstr!(k)).collect();
-    let kw_array = env
-        .new_object_array(
-            keywords.len() as jsize,
-            "java/lang/String",
-            JObject::null(),
-        )
-        .unwrap();
-    for (i, kw) in keywords.iter().enumerate() {
-        env.set_object_array_element(&kw_array, i as jsize, kw)
-            .unwrap();
+    let keywords = entry
+        .keywords
+        .iter()
+        .map(|keyword| JString::new(env, keyword))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let kw_array =
+        JObjectArray::<JString>::new(env, keywords.len(), &JString::null())?;
+
+    for (index, keyword) in keywords.iter().enumerate() {
+        kw_array.set_element(env, index, keyword)?;
     }
 
-    let categories: Vec<JString<'l>> =
-        entry.categories.iter().map(|c| to_jstr!(c)).collect();
-    let cat_array = env
-        .new_object_array(
-            categories.len() as jsize,
-            "java/lang/String",
-            JObject::null(),
-        )
-        .unwrap();
-    for (i, cat) in categories.iter().enumerate() {
-        env.set_object_array_element(&cat_array, i as jsize, cat)
-            .unwrap();
+    let categories = entry
+        .categories
+        .iter()
+        .map(|keyword| JString::new(env, keyword))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let cat_array =
+        JObjectArray::<JString>::new(env, categories.len(), &JString::null())?;
+
+    for (index, category) in categories.iter().enumerate() {
+        cat_array.set_element(env, index, category)?;
     }
 
-    let str_sig = "Ljava/lang/String;";
-    let str_arr_sig = "[Ljava/lang/String;";
-    let mut ctor_sig = String::new();
-    ctor_sig += "(";
-    ctor_sig += str_sig; // appId
-    ctor_sig += str_sig; // name
-    ctor_sig += str_sig; // genericName
-    ctor_sig += str_sig; // exec
-    ctor_sig += "Z"; // execTerminal
-    ctor_sig += str_sig; // comment
-    ctor_sig += str_arr_sig; // keywords
-    ctor_sig += str_arr_sig; // categories
-    ctor_sig += "Z"; // visible
-    ctor_sig += str_sig; // iconPath
-    ctor_sig += ")V";
-
-    let ctor_args = [
-        JValue::Object(&app_id),
-        JValue::Object(&name),
-        JValue::Object(&generic_name),
-        JValue::Object(&exec),
-        JValue::Bool(exec_terminal),
-        JValue::Object(&comment),
-        JValue::Object(&kw_array),
-        JValue::Object(&cat_array),
-        JValue::Bool(visible),
-        JValue::Object(&icon_path),
-    ];
-
-    env.new_object(RawDesktopEntry_class, ctor_sig, &ctor_args)
-        .unwrap()
+    Ok(JRawDesktopEntry::new(
+        env,
+        app_id,
+        name,
+        generic_name,
+        exec,
+        exec_terminal,
+        comment,
+        kw_array,
+        cat_array,
+        visible,
+        icon_path,
+    )?)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    loadDesktopEntry")]
-pub extern "system" fn loadDesktopEntry<'l>(
-    mut env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    jpath: JString<'l>,
-) -> jobject {
-    let instance = jptr_to_instance(ptr);
-    let path: String =
-        unsafe { env.get_string_unchecked(&jpath).unwrap() }.into();
-    let path: PathBuf = path.into();
+fn load_desktop_entry<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    path: JString<'local>,
+) -> Result<JRawDesktopEntry<'local>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "loadDesktopEntry")?;
+    let path: PathBuf = path.try_to_string(env)?.into();
     let entry = match instance.xdg.load_entry(path) {
         Some(e) => e,
-        None => return std::ptr::null_mut(),
+        None => return Ok(JRawDesktopEntry::null()),
     };
 
-    raw_desktop_entry_to_java(&mut env, &entry).into_raw()
+    raw_desktop_entry_to_java(env, &entry)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    loadDesktopEntries")]
-pub extern "system" fn loadDesktopEntries<'l>(
-    mut env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
+fn load_desktop_entries<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JObjectArray<'local, JRawDesktopEntry<'local>>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "loadDesktopEntries")?;
     let entries = instance.xdg.get_raw_entries();
-    let entries: Vec<JObject<'l>> = entries
+    let entries = entries
         .iter()
-        .map(|e| raw_desktop_entry_to_java(&mut env, e))
-        .collect();
+        .map(|e| raw_desktop_entry_to_java(env, e))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let array = env
-        .new_object_array(
-            entries.len() as jsize,
-            RawDesktopEntry_class,
-            JObject::null(),
-        )
-        .unwrap();
-
-    for (i, ent) in entries.iter().enumerate() {
-        env.set_object_array_element(&array, i as jsize, ent)
-            .unwrap();
+    let array = JObjectArray::<JRawDesktopEntry>::new(
+        env,
+        entries.len(),
+        &JRawDesktopEntry::null(),
+    )?;
+    for (index, entry) in entries.iter().enumerate() {
+        array.set_element(env, index, entry)?;
     }
 
-    array.into_raw()
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    renderSVG")]
-pub extern "system" fn renderSVG<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    path: JString<'l>,
+fn render_svg<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    path: JString<'local>,
     width: jint,
     height: jint,
-    ptr: jlong,
-) -> jboolean {
-    let path: String =
-        unsafe { env.get_string_unchecked(&path).unwrap() }.into();
-    let path: PathBuf = path.into();
-    let data = (ptr as usize) as *mut u8;
+    buffer_ptr: jlong,
+) -> Result<jboolean, WLCBError> {
+    let path: PathBuf = path.try_to_string(env)?.into();
+    let data = (buffer_ptr as usize) as *mut u8;
     let width = width as u32;
     let height = height as u32;
 
-    render_svg(path, width, height, data).is_some() as jboolean
+    Ok(crate::svg::render_svg(path, width, height, data).is_some())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    execApp")]
-pub extern "system" fn execApp<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    app_id: JString<'l>,
-) -> jboolean {
-    let instance = jptr_to_instance(ptr);
-    let app_id: String =
-        unsafe { env.get_string_unchecked(&app_id).unwrap() }.into();
+fn exec_app<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    app_id: JString<'local>,
+) -> Result<jboolean, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "renderSvg")?;
+    let app_id = app_id.try_to_string(env)?;
 
     let env_vars = vec![
         ("WAYLAND_DISPLAY".into(), instance.state.socket.clone()),
@@ -1782,128 +1793,118 @@ pub extern "system" fn execApp<'l>(
         ("ELECTRON_OZONE_PLATFORM_HINT".into(), "auto".into()),
         ("GDK_BACKEND".into(), "wayland".into()),
     ];
-    instance.xdg.exec_app(app_id, env_vars) as jboolean
+
+    Ok(instance.xdg.exec_app(app_id, env_vars))
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    setKeymapDefault")]
-pub extern "system" fn setKeymapDefault<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn set_keymap_default<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "execApp")?;
     instance.state.seat.change_keymap_to_default();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    exportKeymap")]
-pub extern "system" fn exportKeymap<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jstring {
-    let instance = jptr_to_instance(ptr);
+fn export_keymap<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JString<'local>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "setKeymapDefault")?;
     let keymap_str = instance.state.seat.export_keymap();
-    env.new_string(keymap_str).unwrap().into_raw()
+    Ok(JString::new(env, keymap_str)?)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    setKeymapFromStr")]
-pub extern "system" fn setKeymapFromStr<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    keymap_str: JString<'l>,
-) -> jboolean {
-    let instance = jptr_to_instance(ptr);
-    let keymap_str: String =
-        unsafe { env.get_string_unchecked(&keymap_str).unwrap() }.into();
-
-    instance.state.seat.change_keymap_from_str(keymap_str) as jboolean
+fn set_keymap_from_str<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    keymap: JString<'local>,
+) -> Result<jboolean, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "exportKeymap")?;
+    let keymap_str = keymap.try_to_string(env)?;
+    Ok(instance.state.seat.change_keymap_from_str(keymap_str))
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    checkDndRequest")]
-pub extern "system" fn checkDndRequest<'l>(
-    env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jarray {
-    let instance = jptr_to_instance(ptr);
-    let request = match instance.state.data.check_dnd_request() {
-        Some(r) => r,
-        None => return std::ptr::null_mut(),
+fn check_dnd_request<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "setKeymapFromStr")?;
+    let serial = match instance.state.data.check_dnd_request() {
+        Some(r) => r as jint,
+        None => return Ok(JIntArray::null()),
     };
 
-    let serial = request as jint;
-    let array = env.new_int_array(1).unwrap();
-    env.set_int_array_region(&array, 0, &[serial]).unwrap();
-    array.into_raw()
+    let array = JIntArray::new(env, 1)?;
+    array.set_region(env, 0, &[serial])?;
+    Ok(array)
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    checkDndActive")]
-pub extern "system" fn checkDndActive<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jboolean {
-    let instance = jptr_to_instance(ptr);
-    instance.state.data.dnd.is_some() as jboolean
+fn check_dnd_active<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<jboolean, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "checkDndRequest")?;
+    Ok(instance.state.data.dnd.is_some())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    dndCancel")]
-pub extern "system" fn dndCancel<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn dnd_cancel<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "checkDndActive")?;
     instance.state.data.dnd_cancel();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    dndDrop")]
-pub extern "system" fn dndDrop<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) {
-    let instance = jptr_to_instance(ptr);
+fn dnd_drop<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "dndCancel")?;
     instance.state.data.dnd_drop();
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    dndMotion")]
-pub extern "system" fn dndMotion<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-    handle: jlong,
+fn dnd_motion<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+    surface_handle: jlong,
     x: jdouble,
     y: jdouble,
-) {
-    let instance = jptr_to_instance(ptr);
-    let surface = jptr_to_wlsurface(handle);
+) -> Result<(), WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "dndDrop")?;
+    let surface = jptr_to_ref(surface_handle);
     instance.state.data.dnd_motion(surface, x, y);
+
+    Ok(())
 }
 
-#[unsafe(export_name = "Java_dev_evvie_waylandcraft_bridge_WaylandCraftBridge_\
-    dndIcon")]
-pub extern "system" fn dndIcon<'l>(
-    _env: JNIEnv<'l>,
-    _class: JClass<'l>,
-    ptr: jlong,
-) -> jlong {
-    let instance = jptr_to_instance(ptr);
-    let dnd = match &instance.state.data.dnd {
-        Some(d) => d,
-        None => return 0,
+fn dnd_icon<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    wlc_bridge_handle: jlong,
+) -> Result<jlong, WLCBError> {
+    let instance = jptr_to_wlc!(wlc_bridge_handle, "dndMotion")?;
+    let Some(dnd) = &instance.state.data.dnd else {
+        return Ok(0);
     };
+
     match dnd.icon.as_ref() {
-        Some(icon) => insert_get_handle(&mut instance.bridge.surfaces, icon),
-        None => 0,
+        Some(icon) => {
+            Ok(insert_get_handle(&mut instance.bridge.surfaces, icon))
+        }
+        None => Ok(0),
     }
 }

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -103,11 +103,11 @@ bind_java_type! {
             fn = init,
         },
         static extern fn update {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = update,
         },
         static extern fn socket {
-            sig = (wlc_bridge_handle: jlong) -> JString,
+            sig = (instance: jlong) -> JString,
             fn = socket,
         },
         static extern fn send_frame {
@@ -115,15 +115,15 @@ bind_java_type! {
             fn = send_frame,
         },
         static extern fn update_surface_data {
-            sig = (wlc_bridge_handle: jlong, surface: WLCSurface),
+            sig = (instance: jlong, surface: WLCSurface),
             fn = update_surface_data,
         },
         static extern fn toplevels {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = toplevels,
         },
         static extern fn toplevel_surface {
-            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong) -> jlong,
+            sig = (instance: jlong, toplevel_handle: jlong) -> jlong,
             fn = toplevel_surface,
         },
         static extern fn toplevel_title {
@@ -144,55 +144,55 @@ bind_java_type! {
             fn = toplevel_resize_ovr,
         },
         static extern fn minimize_req {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = minimize_req,
         },
         static extern fn maximize_req {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = maximize_req,
         },
         static extern fn unmaximize_req {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = unmaximize_req,
         },
         static extern fn fullscreen_req {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = fullscreen_req,
         },
         static extern fn unfullscreen_req {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = unfullscreen_req,
         },
         static extern fn move_request {
-            sig = (wlc_bridge_handle: jlong) -> jint[],
+            sig = (instance: jlong) -> jint[],
             fn = move_request,
         },
         static extern fn resize_request {
-            sig = (wlc_bridge_handle: jlong) -> jint[],
+            sig = (instance: jlong) -> jint[],
             fn = resize_request,
         },
         static extern fn fullscreened {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = fullscreened,
         },
         static extern fn toplevel_maximize {
-            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong),
+            sig = (instance: jlong, toplevel_handle: jlong),
             fn = toplevel_maximize,
         },
         static extern fn toplevel_fullscreen {
-            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong),
+            sig = (instance: jlong, toplevel_handle: jlong),
             fn = toplevel_fullscreen,
         },
         static extern fn popups {
-            sig = (wlc_bridge_handle: jlong) -> jlong[],
+            sig = (instance: jlong) -> jlong[],
             fn = popups,
         },
         static extern fn popup_surface {
-            sig = (wlc_bridge_handle: jlong, popup_handle: jlong) -> jlong,
+            sig = (instance: jlong, popup_handle: jlong) -> jlong,
             fn = popup_surface,
         },
         static extern fn popup_parent {
-            sig = (wlc_bridge_handle: jlong, popup_handle: jlong) -> jlong,
+            sig = (instance: jlong, popup_handle: jlong) -> jlong,
             fn = popup_parent,
         },
         static extern fn popup_offset {
@@ -205,11 +205,11 @@ bind_java_type! {
             fn = surface_xdg_geometry,
         },
         static extern fn delete_dmabuf {
-            sig = (wlc_bridge_handle: jlong, dmabuf_handle: jlong),
+            sig = (instance: jlong, dmabuf_handle: jlong),
             fn = delete_dmabuf
         },
         extern fn update_surface_tree {
-            sig = (wlc_bridge_handle: jlong, surface: WLCSurface) -> WLCSurface,
+            sig = (instance: jlong, surface: WLCSurface) -> WLCSurface,
             fn = update_surface_tree,
         },
         static extern fn check_input_region {
@@ -217,95 +217,95 @@ bind_java_type! {
             fn = check_input_region,
         },
         static extern fn pointer_motion {
-            sig = (wlc_bridge_handle: jlong, x: jdouble, y: jdouble),
+            sig = (instance: jlong, x: jdouble, y: jdouble),
             fn = pointer_motion,
         },
         static extern fn pointer_motion_focus {
-            sig = (wlc_bridge_handle: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
+            sig = (instance: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
             fn = pointer_motion_focus,
         },
         static extern fn pointer_rel_motion {
-            sig = (wlc_bridge_handle: jlong, dx: jdouble, dy: jdouble),
+            sig = (instance: jlong, dx: jdouble, dy: jdouble),
             fn = pointer_rel_motion,
         },
         static extern fn maybe_pointer_lock {
-            sig = (wlc_bridge_handle: jlong, surface_handle: jlong) -> jboolean,
+            sig = (instance: jlong, surface_handle: jlong) -> jboolean,
             fn = maybe_pointer_lock,
         },
         static extern fn pointer_unlock {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = pointer_unlock,
         },
         static extern fn pointer_leave {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = pointer_leave,
         },
         static extern fn pointer_button {
-            sig = (wlc_bridge_handle: jlong, button: jint, state: jint) -> jint,
+            sig = (instance: jlong, button: jint, state: jint) -> jint,
             fn = pointer_button,
         },
         static extern fn pointer_axis {
-            sig = (wlc_bridge_handle: jlong, axis: jint, value: jdouble),
+            sig = (instance: jlong, axis: jint, value: jdouble),
             fn = pointer_axis,
         },
         static extern fn cursor_shape {
-            sig = (wlc_bridge_handle: jlong) -> jint,
+            sig = (instance: jlong) -> jint,
             fn = cursor_shape,
         },
         static extern fn keyboard_focus {
-            sig = (wlc_bridge_handle: jlong, surface_handle: jlong),
+            sig = (instance: jlong, surface_handle: jlong),
             fn = keyboard_focus,
         },
         static extern fn keyboard_activate {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = keyboard_activate,
         },
         static extern fn keyboard_deactivate {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = keyboard_deactivate,
         },
         static extern fn keyboard_input {
-            sig = (wlc_bridge_handle: jlong, scancode: jint, action: jint),
+            sig = (instance: jlong, scancode: jint, action: jint),
             fn = keyboard_input,
         },
         static extern fn keyboard_update {
-            sig = (wlc_bridge_handle: jlong, scancode: jint, pressed: jboolean),
+            sig = (instance: jlong, scancode: jint, pressed: jboolean),
             fn = keyboard_update,
         },
         static extern fn output_size {
-            sig = (wlc_bridge_handle: jlong) -> jint[],
+            sig = (instance: jlong) -> jint[],
             fn = output_size,
         },
         static extern fn output_bounds {
-            sig = (wlc_bridge_handle: jlong) -> jint[],
+            sig = (instance: jlong) -> jint[],
             fn = output_bounds,
         },
         static extern fn output_resize {
-            sig = (wlc_bridge_handle: jlong, width: jint, height: jint),
+            sig = (instance: jlong, width: jint, height: jint),
             fn = output_resize,
         },
         static extern fn output_set_bounds {
-            sig = (wlc_bridge_handle: jlong, width: jint, height: jint),
+            sig = (instance: jlong, width: jint, height: jint),
             fn = output_set_bounds,
         },
         static extern fn free_surface {
-            sig = (wlc_bridge_handle: jlong, surface_handle: jlong),
+            sig = (instance: jlong, surface_handle: jlong),
             fn = free_surface,
         },
         static extern fn free_toplevel {
-            sig = (wlc_bridge_handle: jlong, toplevel_handle: jlong),
+            sig = (instance: jlong, toplevel_handle: jlong),
             fn = free_toplevel,
         },
         static extern fn free_popup {
-            sig = (wlc_bridge_handle: jlong, popup_handle: jlong),
+            sig = (instance: jlong, popup_handle: jlong),
             fn = free_popup,
         },
         static extern fn load_desktop_entry {
-            sig = (wlc_bridge_handle: jlong, path: JString) -> JRawDesktopEntry,
+            sig = (instance: jlong, path: JString) -> JRawDesktopEntry,
             fn = load_desktop_entry,
         },
         static extern fn load_desktop_entries {
-            sig = (wlc_bridge_handle: jlong) -> JRawDesktopEntry[],
+            sig = (instance: jlong) -> JRawDesktopEntry[],
             fn = load_desktop_entries,
         },
         static extern fn render_svg {
@@ -314,50 +314,50 @@ bind_java_type! {
             fn = render_svg,
         },
         static extern fn exec_app {
-            sig = (wlc_bridge_handle: jlong, app_id: JString) -> jboolean,
+            sig = (instance: jlong, app_id: JString) -> jboolean,
             fn = exec_app,
         },
         static extern fn set_keymap_default {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = set_keymap_default,
         },
         static extern fn export_keymap {
-            sig = (wlc_bridge_handle: jlong) -> JString,
+            sig = (instance: jlong) -> JString,
             fn = export_keymap,
         },
         static extern fn set_keymap_from_str {
-            sig = (wlc_bridge_handle: jlong, keymap: JString) -> jboolean,
+            sig = (instance: jlong, keymap: JString) -> jboolean,
             fn = set_keymap_from_str,
         },
         static extern fn check_dnd_request {
-            sig = (wlc_bridge_handle: jlong) -> jint[],
+            sig = (instance: jlong) -> jint[],
             fn = check_dnd_request,
         },
         static extern fn check_dnd_active {
-            sig = (wlc_bridge_handle: jlong) -> jboolean,
+            sig = (instance: jlong) -> jboolean,
             fn = check_dnd_active,
         },
         static extern fn dnd_cancel {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = dnd_cancel,
         },
         static extern fn dnd_drop {
-            sig = (wlc_bridge_handle: jlong),
+            sig = (instance: jlong),
             fn = dnd_drop,
         },
         static extern fn dnd_motion {
-            sig = (wlc_bridge_handle: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
+            sig = (instance: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
             fn = dnd_motion,
         },
         static extern fn dnd_icon {
-            sig = (wlc_bridge_handle: jlong) -> jlong,
+            sig = (instance: jlong) -> jlong,
             fn = dnd_icon,
         },
     },
 }
 
 #[derive(Debug, Error)]
-enum WLCBError {
+enum BridgeError {
     #[error(transparent)]
     JniError(#[from] jni::errors::Error),
     #[error(transparent)]
@@ -365,13 +365,13 @@ enum WLCBError {
     #[error("{0}")]
     Null(&'static str),
     #[error("Null WLC instance handle given. Function: {0}")]
-    NullWlcInstance(&'static str),
+    NullInstancePtr(&'static str),
     #[error("Null wayland surface handle given. Function: {0}")]
-    NullWaylandSurface(&'static str),
+    NullSurfacePtr(&'static str),
     #[error("Null toplevel surface handle given. Function: {0}")]
-    NullToplevelSurface(&'static str),
+    NullToplevelPtr(&'static str),
     #[error("Null popup surface handle given. Function: {0}")]
-    NullPopupSurface(&'static str),
+    NullPopupPtr(&'static str),
     #[error("Error converting OS string, was not UTF8")]
     OsStringToUtf8,
     #[error("Unknown pointer button {0} received")]
@@ -386,10 +386,10 @@ enum WLCBError {
     NonPositiveHeight,
 }
 
-macro_rules! jptr_to_wlc {
+macro_rules! jptr_to_instance {
     ($jptr:expr, $location:literal) => {
         match jptr_to_mut::<WaylandCraft>($jptr) {
-            None => Err(WLCBError::NullWlcInstance($location)),
+            None => Err(BridgeError::NullInstancePtr($location)),
             Some(wlc) => Ok(wlc),
         }
     };
@@ -398,7 +398,7 @@ macro_rules! jptr_to_wlc {
 macro_rules! jptr_to_wl_surface {
     ($jptr:expr, $location:literal) => {
         match jptr_to_mut::<WlSurface>($jptr) {
-            None => Err(WLCBError::NullWaylandSurface($location)),
+            None => Err(BridgeError::NullSurfacePtr($location)),
             Some(wl_surface) => Ok(wl_surface),
         }
     };
@@ -407,7 +407,7 @@ macro_rules! jptr_to_wl_surface {
 macro_rules! jptr_to_toplevel {
     ($jptr:expr, $location:literal) => {
         match jptr_to_mut::<ToplevelSurface>($jptr) {
-            None => Err(WLCBError::NullToplevelSurface($location)),
+            None => Err(BridgeError::NullToplevelPtr($location)),
             Some(toplevel) => Ok(toplevel),
         }
     };
@@ -416,7 +416,7 @@ macro_rules! jptr_to_toplevel {
 macro_rules! jptr_to_popup {
     ($jptr:expr, $location:literal) => {
         match jptr_to_mut::<PopupSurface>($jptr) {
-            None => Err(WLCBError::NullPopupSurface($location)),
+            None => Err(BridgeError::NullPopupPtr($location)),
             Some(popup) => Ok(popup),
         }
     };
@@ -427,11 +427,11 @@ fn init<'local>(
     _class: JClass<'local>,
     glfw_get_proc_address: jlong,
     egl_display: jlong,
-) -> Result<jlong, WLCBError> {
+) -> Result<jlong, BridgeError> {
     let dpy: EGLDisplay = (egl_display as usize) as EGLDisplay;
     let egl = EGLHelper::new(dpy, glfw_get_proc_address as usize);
 
-    let instance = wlc_init(egl).map_err(WLCBError::Init)?;
+    let instance = wlc_init(egl).map_err(BridgeError::Init)?;
     let instance_box = Box::new(instance);
     let ptr = Box::into_raw(instance_box);
 
@@ -441,9 +441,9 @@ fn init<'local>(
 fn update<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    jptr_to_wlc!(wlc_bridge_handle, "update")?.update();
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    jptr_to_instance!(instance, "update")?.update();
 
     Ok(())
 }
@@ -451,14 +451,14 @@ fn update<'local>(
 fn socket<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JString<'local>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "socket")?;
+    instance: jlong,
+) -> Result<JString<'local>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "socket")?;
     let socket = instance
         .state
         .socket
         .to_str()
-        .ok_or(WLCBError::OsStringToUtf8)?;
+        .ok_or(BridgeError::OsStringToUtf8)?;
 
     Ok(JString::new(env, socket)?)
 }
@@ -467,7 +467,7 @@ fn send_frame<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
     surface_handle: jlong,
-) -> Result<(), WLCBError> {
+) -> Result<(), BridgeError> {
     let surface = jptr_to_wl_surface!(surface_handle, "sendFrame")?;
 
     with_surface_data(surface, |data| {
@@ -539,9 +539,9 @@ where
 fn toplevels<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevels")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "toplevels")?;
 
     insert_all(
         &mut instance.bridge.toplevels,
@@ -559,9 +559,9 @@ fn toplevels<'local>(
 fn popups<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "popups")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "popups")?;
 
     insert_all(
         &mut instance.bridge.popups,
@@ -588,7 +588,7 @@ fn clear_requests<'local>(
     env: &mut Env<'local>,
     instance: &mut WaylandCraft,
     vec: RequestsVec,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
     let vec = match vec {
         RequestsVec::Minimize => &mut instance.state.requests.minimize,
         RequestsVec::Maximize => &mut instance.state.requests.maximize,
@@ -613,54 +613,54 @@ fn clear_requests<'local>(
 fn minimize_req<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "minimizeReq")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "minimizeReq")?;
     clear_requests(env, instance, RequestsVec::Minimize)
 }
 
 fn maximize_req<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "maximizeReq")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "maximizeReq")?;
     clear_requests(env, instance, RequestsVec::Maximize)
 }
 
 fn unmaximize_req<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "unmaximizeReq")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "unmaximizeReq")?;
     clear_requests(env, instance, RequestsVec::Unmaximize)
 }
 
 fn fullscreen_req<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "fullscreenReq")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "fullscreenReq")?;
     clear_requests(env, instance, RequestsVec::Fullscreen)
 }
 
 fn unfullscreen_req<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "unfullscreenReq")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "unfullscreenReq")?;
     clear_requests(env, instance, RequestsVec::Unfullscreen)
 }
 
 fn move_request<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "moveRequest")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "moveRequest")?;
     let serial = instance.state.requests.move_interactive.pop();
 
     let serial = match serial {
@@ -678,9 +678,9 @@ fn move_request<'local>(
 fn resize_request<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "resizeRequest")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "resizeRequest")?;
     let req = instance.state.requests.resize_interactive.pop();
 
     let (serial, edges) = match req {
@@ -800,13 +800,13 @@ fn try_attach_dmabuf(
 fn delete_dmabuf<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     dmabuf_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "deleteDmabuf")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "deleteDmabuf")?;
     let dmabuf = jptr_to_ref::<Dmabuf>(dmabuf_handle).ok_or_else(|| {
-        WLCBError::Null(
-            "deleteDmabuf: dmabuf does not exist",
+        BridgeError::Null(
+            "deleteDmabuf: dmabufHandle is null",
         )
     })?;
 
@@ -848,15 +848,15 @@ fn try_attach_buffer(
 fn update_surface_data<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     jsurface: WLCSurface<'local>,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "updateSurfaceData")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "updateSurfaceData")?;
 
     let handle = jsurface.handle(env)?;
     let surface = jptr_to_ref::<WlSurface>(handle).ok_or_else(|| {
-        WLCBError::Null(
-            "updateSufaceData: WLCSurface.handle() returned a null pointer",
+        BridgeError::Null(
+            "updateSufaceData: surfaceHandle is null",
         )
     })?;
 
@@ -911,10 +911,10 @@ fn update_surface_data<'local>(
 fn toplevel_surface<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     toplevel_handle: jlong,
-) -> Result<jlong, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevelSurface")?;
+) -> Result<jlong, BridgeError> {
+    let instance = jptr_to_instance!(instance, "toplevelSurface")?;
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelSurface")?;
 
     let surface = toplevel.wl_surface();
@@ -925,10 +925,10 @@ fn toplevel_surface<'local>(
 fn popup_surface<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     popup_handle: jlong,
-) -> Result<jlong, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "popupSurface")?;
+) -> Result<jlong, BridgeError> {
+    let instance = jptr_to_instance!(instance, "popupSurface")?;
     let popup = jptr_to_popup!(popup_handle, "popupSurface")?;
 
     let surface = popup.wl_surface();
@@ -939,10 +939,10 @@ fn popup_surface<'local>(
 fn popup_parent<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     popup_handle: jlong,
-) -> Result<jlong, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "popupParent")?;
+) -> Result<jlong, BridgeError> {
+    let instance = jptr_to_instance!(instance, "popupParent")?;
     let popup = jptr_to_popup!(popup_handle, "popupParent")?;
 
     let parent_surface = match popup.get_parent_surface() {
@@ -969,7 +969,7 @@ fn popup_offset<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
     popup_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
     let popup = jptr_to_popup!(popup_handle, "popupOffset")?;
 
     let mut offset: [jint; 2] = [0, 0];
@@ -991,15 +991,15 @@ fn popup_offset<'local>(
 fn update_surface_tree<'local>(
     env: &mut Env<'local>,
     this: WaylandCraftBridge<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     surface: WLCSurface<'local>,
-) -> Result<WLCSurface<'local>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "updateSurfaceTrees")?;
+) -> Result<WLCSurface<'local>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "updateSurfaceTrees")?;
 
     let handle = surface.handle(env)?;
     let surface = jptr_to_ref::<WlSurface>(handle).ok_or_else(|| {
-        WLCBError::Null(
-            "updateSufaceTree: WLCSurface.handle() returned a null pointer",
+        BridgeError::Null(
+            "updateSufaceTree: surface is not alive",
         )
     })?;
 
@@ -1063,11 +1063,11 @@ fn update_surface_tree<'local>(
 fn pointer_motion<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     x: jdouble,
     y: jdouble,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerMotion")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerMotion")?;
     instance.state.seat.pointer_motion(x, y);
 
     Ok(())
@@ -1076,12 +1076,12 @@ fn pointer_motion<'local>(
 fn pointer_motion_focus<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     surface_handle: jlong,
     x: jdouble,
     y: jdouble,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerMotionFocus")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerMotionFocus")?;
     let surface = jptr_to_ref(surface_handle);
     instance.state.seat.pointer_motion_focus(surface, x, y);
 
@@ -1091,11 +1091,11 @@ fn pointer_motion_focus<'local>(
 fn pointer_rel_motion<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     dx: jdouble,
     dy: jdouble,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerRelMotion")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerRelMotion")?;
     instance.state.seat.pointer_relative_motion(dx, dy);
 
     Ok(())
@@ -1104,10 +1104,10 @@ fn pointer_rel_motion<'local>(
 fn maybe_pointer_lock<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     surface_handle: jlong,
-) -> Result<jboolean, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "maybePointerLock")?;
+) -> Result<jboolean, BridgeError> {
+    let instance = jptr_to_instance!(instance, "maybePointerLock")?;
     let Some(surface) = jptr_to_ref(surface_handle) else {
         return Ok(false);
     };
@@ -1118,9 +1118,9 @@ fn maybe_pointer_lock<'local>(
 fn pointer_unlock<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerUnlock")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerUnlock")?;
     instance.state.seat.pointer_unlock();
 
     Ok(())
@@ -1129,9 +1129,9 @@ fn pointer_unlock<'local>(
 fn pointer_leave<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerLeave")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerLeave")?;
     instance.state.seat.pointer_motion_focus(None, 0.0, 0.0);
 
     Ok(())
@@ -1140,16 +1140,16 @@ fn pointer_leave<'local>(
 fn pointer_button<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     button: jint,
     state: jint,
-) -> Result<jint, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerButton")?;
+) -> Result<jint, BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerButton")?;
 
     let state = match state {
         0 => ButtonState::Released,
         1 => ButtonState::Pressed,
-        _ => return Err(WLCBError::UnknownPointerButton(state)),
+        _ => return Err(BridgeError::UnknownPointerButton(state)),
     };
 
     Ok(instance.state.seat.pointer_button(button as u32, state) as jint)
@@ -1158,17 +1158,17 @@ fn pointer_button<'local>(
 fn pointer_axis<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     axis: jint,
     value: jdouble,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "pointerAxis")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "pointerAxis")?;
 
     let axis = match axis {
         0 => Axis::VerticalScroll,
         1 => Axis::HorizontalScroll,
         _ => {
-            return Err(WLCBError::UnknownScrollDirection(axis));
+            return Err(BridgeError::UnknownScrollDirection(axis));
         }
     };
 
@@ -1178,9 +1178,9 @@ fn pointer_axis<'local>(
 fn cursor_shape<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<jint, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "cursorShape")?;
+    instance: jlong,
+) -> Result<jint, BridgeError> {
+    let instance = jptr_to_instance!(instance, "cursorShape")?;
 
     let shape = match instance.state.seat.cursor_shape {
         Some(shape) => shape as jint,
@@ -1193,10 +1193,10 @@ fn cursor_shape<'local>(
 fn keyboard_focus<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     surface_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardFocus")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "keyboardFocus")?;
     let toplevel: Option<&ToplevelSurface> = jptr_to_ref(surface_handle);
 
     let surface = toplevel.map(|t| t.wl_surface().clone());
@@ -1242,9 +1242,9 @@ fn keyboard_focus<'local>(
 fn keyboard_activate<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardActivate")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "keyboardActivate")?;
     instance.state.seat.activate_keyboard();
 
     Ok(())
@@ -1253,9 +1253,9 @@ fn keyboard_activate<'local>(
 fn keyboard_deactivate<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardDeactivate")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "keyboardDeactivate")?;
     instance.state.seat.deactivate_keyboard();
 
     Ok(())
@@ -1264,18 +1264,18 @@ fn keyboard_deactivate<'local>(
 fn keyboard_input<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     scancode: jint,
     action: jint,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardInput")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "keyboardInput")?;
 
     let scancode = scancode as u32;
     let action = match action {
         0 => KeyState::Released,
         1 => KeyState::Pressed,
         _ => {
-            return Err(WLCBError::UnknownKeyboardState(action));
+            return Err(BridgeError::UnknownKeyboardState(action));
         }
     };
 
@@ -1287,11 +1287,11 @@ fn keyboard_input<'local>(
 fn keyboard_update<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     scancode: jint,
     pressed: jboolean,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "keyboardUpdate")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "keyboardUpdate")?;
     instance
         .state
         .seat
@@ -1303,9 +1303,9 @@ fn keyboard_update<'local>(
 fn fullscreened<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jlong>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "fullscreened")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "fullscreened")?;
 
     let mut handles: Vec<jlong> = vec![];
     for toplevel in instance.state.xdg_state.toplevel_surfaces() {
@@ -1331,9 +1331,9 @@ fn fullscreened<'local>(
 fn output_size<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputSize")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "outputSize")?;
 
     let size = instance.state.output.size();
     let size: [jint; 2] = [size.w, size.h];
@@ -1346,9 +1346,9 @@ fn output_size<'local>(
 fn output_bounds<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputBounds")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "outputBounds")?;
 
     let bounds = instance.state.output.bounds();
     let bounds: [jint; 2] = [bounds.w, bounds.h];
@@ -1361,19 +1361,19 @@ fn output_bounds<'local>(
 fn output_resize<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     width: jint,
     height: jint,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputResize")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "outputResize")?;
     let size = instance.state.output.size();
     let width_changed = size.w != width;
     let height_changed = size.h != height;
 
     if width < 1 {
-        return Err(WLCBError::NonPositiveWidth);
+        return Err(BridgeError::NonPositiveWidth);
     } else if height < 1 {
-        return Err(WLCBError::NonPositiveHeight);
+        return Err(BridgeError::NonPositiveHeight);
     }
 
     if !width_changed && !height_changed {
@@ -1398,19 +1398,19 @@ fn output_resize<'local>(
 fn output_set_bounds<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     width: jint,
     height: jint,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "outputSetBounds")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "outputSetBounds")?;
     let bounds = instance.state.output.bounds();
     let width_changed = bounds.w != width;
     let height_changed = bounds.h != height;
 
     if width < 1 {
-        return Err(WLCBError::NonPositiveWidth);
+        return Err(BridgeError::NonPositiveWidth);
     } else if height < 1 {
-        return Err(WLCBError::NonPositiveHeight);
+        return Err(BridgeError::NonPositiveHeight);
     }
 
     if !width_changed && !height_changed {
@@ -1438,7 +1438,7 @@ fn check_input_region<'local>(
     surface_handle: jlong,
     x: jdouble,
     y: jdouble,
-) -> Result<jboolean, WLCBError> {
+) -> Result<jboolean, BridgeError> {
     let Some(surface) = jptr_to_ref(surface_handle) else {
         return Ok(false);
     };
@@ -1460,7 +1460,7 @@ fn surface_xdg_geometry<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
     surface_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
     let surface = match jptr_to_ref(surface_handle) {
         Some(s) => s,
         None => return Ok(JIntArray::null()),
@@ -1487,7 +1487,7 @@ fn toplevel_title<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
     toplevel_handle: jlong,
-) -> Result<JString<'local>, WLCBError> {
+) -> Result<JString<'local>, BridgeError> {
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelTitle")?;
 
     let surface = toplevel.wl_surface();
@@ -1514,7 +1514,7 @@ fn toplevel_app_id<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
     toplevel_handle: jlong,
-) -> Result<JString<'local>, WLCBError> {
+) -> Result<JString<'local>, BridgeError> {
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelAppId")?;
 
     let surface = toplevel.wl_surface();
@@ -1544,7 +1544,7 @@ fn toplevel_resize<'local>(
     width: jint,
     height: jint,
     interactive: jboolean,
-) -> Result<(), WLCBError> {
+) -> Result<(), BridgeError> {
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelResize")?;
 
     toplevel.with_pending_state(|state| {
@@ -1569,7 +1569,7 @@ fn toplevel_resize_ovr<'local>(
     toplevel_handle: jlong,
     width: jint,
     height: jint,
-) -> Result<(), WLCBError> {
+) -> Result<(), BridgeError> {
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelResizeOvr")?;
 
     toplevel.with_pending_state(|state| {
@@ -1585,10 +1585,10 @@ fn toplevel_resize_ovr<'local>(
 fn toplevel_maximize<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     toplevel_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevelMaximize")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "toplevelMaximize")?;
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelMaximize")?;
 
     toplevel.with_pending_state(|state| {
@@ -1607,10 +1607,10 @@ fn toplevel_maximize<'local>(
 fn toplevel_fullscreen<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     toplevel_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "toplevelFullscreen")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "toplevelFullscreen")?;
     let toplevel = jptr_to_toplevel!(toplevel_handle, "toplevelFullscreen")?;
 
     toplevel.with_pending_state(|state| {
@@ -1626,10 +1626,10 @@ fn toplevel_fullscreen<'local>(
 fn free_surface<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     surface_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "freeSurface")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "freeSurface")?;
     remove_element(&mut instance.bridge.surfaces, surface_handle);
 
     Ok(())
@@ -1638,10 +1638,10 @@ fn free_surface<'local>(
 fn free_toplevel<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     toplevel_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "freeToplevel")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "freeToplevel")?;
     remove_element(&mut instance.bridge.toplevels, toplevel_handle);
 
     Ok(())
@@ -1650,10 +1650,10 @@ fn free_toplevel<'local>(
 fn free_popup<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     popup_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "freePopup")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "freePopup")?;
     remove_element(&mut instance.bridge.popups, popup_handle);
 
     Ok(())
@@ -1662,7 +1662,7 @@ fn free_popup<'local>(
 fn raw_desktop_entry_to_java<'local>(
     env: &mut Env<'local>,
     entry: &RawDesktopEntry,
-) -> Result<JRawDesktopEntry<'local>, WLCBError> {
+) -> Result<JRawDesktopEntry<'local>, BridgeError> {
     macro_rules! opt_to_jstring {
         ($env:expr, $string:expr) => {
             match $string {
@@ -1725,10 +1725,10 @@ fn raw_desktop_entry_to_java<'local>(
 fn load_desktop_entry<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     path: JString<'local>,
-) -> Result<JRawDesktopEntry<'local>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "loadDesktopEntry")?;
+) -> Result<JRawDesktopEntry<'local>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "loadDesktopEntry")?;
     let path: PathBuf = path.try_to_string(env)?.into();
     let entry = match instance.xdg.load_entry(path) {
         Some(e) => e,
@@ -1741,9 +1741,9 @@ fn load_desktop_entry<'local>(
 fn load_desktop_entries<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JObjectArray<'local, JRawDesktopEntry<'local>>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "loadDesktopEntries")?;
+    instance: jlong,
+) -> Result<JObjectArray<'local, JRawDesktopEntry<'local>>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "loadDesktopEntries")?;
     let entries = instance.xdg.get_raw_entries();
     let entries = entries
         .iter()
@@ -1769,7 +1769,7 @@ fn render_svg<'local>(
     width: jint,
     height: jint,
     buffer_ptr: jlong,
-) -> Result<jboolean, WLCBError> {
+) -> Result<jboolean, BridgeError> {
     let path: PathBuf = path.try_to_string(env)?.into();
     let data = (buffer_ptr as usize) as *mut u8;
     let width = width as u32;
@@ -1781,10 +1781,10 @@ fn render_svg<'local>(
 fn exec_app<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     app_id: JString<'local>,
-) -> Result<jboolean, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "renderSvg")?;
+) -> Result<jboolean, BridgeError> {
+    let instance = jptr_to_instance!(instance, "execApp")?;
     let app_id = app_id.try_to_string(env)?;
 
     let env_vars = vec![
@@ -1800,9 +1800,9 @@ fn exec_app<'local>(
 fn set_keymap_default<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "execApp")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "setKeymapDefault")?;
     instance.state.seat.change_keymap_to_default();
 
     Ok(())
@@ -1811,9 +1811,9 @@ fn set_keymap_default<'local>(
 fn export_keymap<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JString<'local>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "setKeymapDefault")?;
+    instance: jlong,
+) -> Result<JString<'local>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "exportKeymap")?;
     let keymap_str = instance.state.seat.export_keymap();
     Ok(JString::new(env, keymap_str)?)
 }
@@ -1821,10 +1821,10 @@ fn export_keymap<'local>(
 fn set_keymap_from_str<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     keymap: JString<'local>,
-) -> Result<jboolean, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "exportKeymap")?;
+) -> Result<jboolean, BridgeError> {
+    let instance = jptr_to_instance!(instance, "setKeymapFromStr")?;
     let keymap_str = keymap.try_to_string(env)?;
     Ok(instance.state.seat.change_keymap_from_str(keymap_str))
 }
@@ -1832,9 +1832,9 @@ fn set_keymap_from_str<'local>(
 fn check_dnd_request<'local>(
     env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<JPrimitiveArray<'local, jint>, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "setKeymapFromStr")?;
+    instance: jlong,
+) -> Result<JPrimitiveArray<'local, jint>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "checkDndRequest")?;
     let serial = match instance.state.data.check_dnd_request() {
         Some(r) => r as jint,
         None => return Ok(JIntArray::null()),
@@ -1848,18 +1848,18 @@ fn check_dnd_request<'local>(
 fn check_dnd_active<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<jboolean, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "checkDndRequest")?;
+    instance: jlong,
+) -> Result<jboolean, BridgeError> {
+    let instance = jptr_to_instance!(instance, "checkDndActive")?;
     Ok(instance.state.data.dnd.is_some())
 }
 
 fn dnd_cancel<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "checkDndActive")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "dndCancel")?;
     instance.state.data.dnd_cancel();
 
     Ok(())
@@ -1868,9 +1868,9 @@ fn dnd_cancel<'local>(
 fn dnd_drop<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "dndCancel")?;
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "dndDrop")?;
     instance.state.data.dnd_drop();
 
     Ok(())
@@ -1879,12 +1879,12 @@ fn dnd_drop<'local>(
 fn dnd_motion<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
+    instance: jlong,
     surface_handle: jlong,
     x: jdouble,
     y: jdouble,
-) -> Result<(), WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "dndDrop")?;
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "dndMotion")?;
     let surface = jptr_to_ref(surface_handle);
     instance.state.data.dnd_motion(surface, x, y);
 
@@ -1894,9 +1894,9 @@ fn dnd_motion<'local>(
 fn dnd_icon<'local>(
     _env: &mut Env<'local>,
     _class: JClass<'local>,
-    wlc_bridge_handle: jlong,
-) -> Result<jlong, WLCBError> {
-    let instance = jptr_to_wlc!(wlc_bridge_handle, "dndMotion")?;
+    instance: jlong,
+) -> Result<jlong, BridgeError> {
+    let instance = jptr_to_instance!(instance, "dndIcon")?;
     let Some(dnd) = &instance.state.data.dnd else {
         return Ok(0);
     };

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -136,7 +136,12 @@ bind_java_type! {
             fn = toplevel_app_id,
         },
         static extern fn toplevel_resize {
-            sig = (toplevel_handle: jlong, width: jint, height: jint, interactive: jboolean),
+            sig = (
+                toplevel_handle: jlong,
+                width: jint,
+                height: jint,
+                interactive: jboolean
+            ),
             fn = toplevel_resize,
         },
         static extern fn toplevel_resize_ovr {
@@ -221,7 +226,12 @@ bind_java_type! {
             fn = pointer_motion,
         },
         static extern fn pointer_motion_focus {
-            sig = (instance: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
+            sig = (
+                instance: jlong,
+                surface_handle: jlong,
+                x: jdouble,
+                y: jdouble
+            ),
             fn = pointer_motion_focus,
         },
         static extern fn pointer_rel_motion {
@@ -309,7 +319,12 @@ bind_java_type! {
             fn = load_desktop_entries,
         },
         static extern fn render_svg {
-            sig = (path: JString, width: jint, height: jint, buffer_ptr: jlong) -> jboolean,
+            sig = (
+                path: JString,
+                width: jint,
+                height: jint,
+                buffer_ptr: jlong
+            ) -> jboolean,
             name = "renderSVG",
             fn = render_svg,
         },
@@ -346,7 +361,12 @@ bind_java_type! {
             fn = dnd_drop,
         },
         static extern fn dnd_motion {
-            sig = (instance: jlong, surface_handle: jlong, x: jdouble, y: jdouble),
+            sig = (
+                instance: jlong,
+                surface_handle: jlong,
+                x: jdouble,
+                y: jdouble
+            ),
             fn = dnd_motion,
         },
         static extern fn dnd_icon {
@@ -777,7 +797,7 @@ fn try_attach_dmabuf(
 
     // This insert clones the dmabuf reference counter and as such ensures
     // that a strong reference to the dmabuf is kept.
-    let handle = insert_get_handle(&mut instance.bridge.dmabufs, &dmabuf);
+    let handle = insert_get_handle(&mut instance.bridge.dmabufs, dmabuf);
 
     let already_attached = jsurface.attach_dmabuf(env, handle).unwrap();
 
@@ -805,9 +825,7 @@ fn delete_dmabuf<'local>(
 ) -> Result<(), BridgeError> {
     let instance = jptr_to_instance!(instance, "deleteDmabuf")?;
     let dmabuf = jptr_to_ref::<Dmabuf>(dmabuf_handle).ok_or_else(|| {
-        BridgeError::Null(
-            "deleteDmabuf: dmabufHandle is null",
-        )
+        BridgeError::Null("deleteDmabuf: dmabufHandle is null")
     })?;
 
     instance.bridge.dmabufs.retain(|d| **d != *dmabuf);
@@ -855,12 +873,10 @@ fn update_surface_data<'local>(
 
     let handle = jsurface.handle(env)?;
     let surface = jptr_to_ref::<WlSurface>(handle).ok_or_else(|| {
-        BridgeError::Null(
-            "updateSufaceData: surfaceHandle is null",
-        )
+        BridgeError::Null("updateSufaceData: surfaceHandle is null")
     })?;
 
-    with_states(&surface, |data| {
+    with_states(surface, |data| {
         let mut attr_guard = data.cached_state.get::<SurfaceAttributes>();
         let attr = attr_guard.deref_mut().current();
 
@@ -998,15 +1014,13 @@ fn update_surface_tree<'local>(
 
     let handle = surface.handle(env)?;
     let surface = jptr_to_ref::<WlSurface>(handle).ok_or_else(|| {
-        BridgeError::Null(
-            "updateSufaceTree: surface is not alive",
-        )
+        BridgeError::Null("updateSufaceTree: surface is not alive")
     })?;
 
     let mut last_child = WLCSurface::null();
 
     with_surface_tree_upward(
-        &surface,
+        surface,
         None,
         |surface, _data, _parent| {
             TraversalAction::DoChildren(Some(surface.clone()))
@@ -1112,7 +1126,7 @@ fn maybe_pointer_lock<'local>(
         return Ok(false);
     };
 
-    Ok(instance.state.seat.pointer_lock(&surface))
+    Ok(instance.state.seat.pointer_lock(surface))
 }
 
 fn pointer_unlock<'local>(
@@ -1172,7 +1186,9 @@ fn pointer_axis<'local>(
         }
     };
 
-    Ok(instance.state.seat.pointer_axis(axis, value))
+    instance.state.seat.pointer_axis(axis, value);
+
+    Ok(())
 }
 
 fn cursor_shape<'local>(
@@ -1445,7 +1461,7 @@ fn check_input_region<'local>(
 
     let point: Point<f64, Logical> = Point::new(x, y);
 
-    Ok(with_states(&surface, |data| {
+    Ok(with_states(surface, |data| {
         let mut attr_guard = data.cached_state.get::<SurfaceAttributes>();
         let attr = attr_guard.deref_mut().current();
         if let Some(r) = &attr.input_region {
@@ -1466,7 +1482,7 @@ fn surface_xdg_geometry<'local>(
         None => return Ok(JIntArray::null()),
     };
 
-    let geometry: Option<[jint; 4]> = with_states(&surface, |states| {
+    let geometry: Option<[jint; 4]> = with_states(surface, |states| {
         let mut guard = states.cached_state.get::<SurfaceCachedState>();
         guard
             .current()

--- a/native/src/ddm.rs
+++ b/native/src/ddm.rs
@@ -242,7 +242,7 @@ impl WLCDataState {
         let focus = self.dnd.as_ref().unwrap().focus.clone();
 
         if source.is_none()
-            && let Some(ref s) = surface
+            && let Some(s) = surface
         {
             let surface_client = s.client().unwrap();
             if surface_client != client {
@@ -301,7 +301,7 @@ impl WLCDataState {
             }
 
             // Make device enter surface
-            device.enter(new_serial(), &surface, x, y, offer.as_ref());
+            device.enter(new_serial(), surface, x, y, offer.as_ref());
             data.dnd_focus = Some(surface.clone());
             data.last_dnd_motion = None;
         });

--- a/native/src/ddm.rs
+++ b/native/src/ddm.rs
@@ -224,7 +224,7 @@ impl WLCDataState {
 
     pub fn dnd_motion(
         &mut self,
-        mut surface: Option<WlSurface>,
+        mut surface: Option<&WlSurface>,
         x: f64,
         y: f64,
     ) {
@@ -251,14 +251,14 @@ impl WLCDataState {
             }
         }
 
-        if surface != focus {
+        if surface != focus.as_ref() {
             // Reset the accepted type when moving to different surface
             if let Some(s) = &source {
                 s.target(None);
             }
             self.dnd.as_mut().unwrap().mime = None;
         }
-        self.dnd.as_mut().unwrap().focus = surface.clone();
+        self.dnd.as_mut().unwrap().focus = surface.cloned();
 
         // Unfocus devices focused on wrong surface
         self.for_all_devices(|device, data| {
@@ -266,7 +266,7 @@ impl WLCDataState {
                 Some(s) => s,
                 None => return,
             };
-            let unfocus = match &surface {
+            let unfocus = match surface {
                 Some(s) => s != focus,
                 None => true,
             };

--- a/native/src/java_types.rs
+++ b/native/src/java_types.rs
@@ -1,0 +1,37 @@
+use jni::bind_java_type;
+
+bind_java_type! {
+    rust_type = WLCSurface,
+    rust_type_vis = pub,
+    java_type = dev.evvie.waylandcraft.bridge.WLCSurface,
+
+    fields {
+        handle: jlong,
+        visited: jboolean,
+        next_child: WLCSurface,
+        prev_child: WLCSurface,
+        parent_handle: jlong,
+        xoff: jint,
+        yoff: jint,
+    },
+
+    methods {
+        pub fn remove_buffer(),
+        pub fn set_viewport_src(x: jdouble, y: jdouble, width: jdouble, height: jdouble),
+        pub fn set_viewport_dst(width: jint, height: jint),
+        pub fn attach_shm_buffer(ptr: jlong, width: jint, height: jint, format: jint, stride: jint),
+        pub fn attach_single_pixel_buffer(red: jbyte, green: jbyte, blue: jbyte, alpha: jbyte),
+        pub fn attach_dmabuf(handle: jlong) -> jboolean,
+        pub fn attach_new_dmabuf(dmabuf_handle: jlong, egl_image_ptr: jlong, width: jint, height: jint),
+    },
+}
+
+bind_java_type! {
+    rust_type = JRawDesktopEntry,
+    rust_type_vis = pub,
+    java_type = dev.evvie.waylandcraft.desktop.RawDesktopEntry,
+
+    constructors {
+        fn new(app_id: JString, name: JString, generic_name: JString, exec: JString, exec_terminal: jboolean, comment: JString, keywords: JString[], categories: JString[], visible: jboolean, icon_path: JString)
+    },
+}

--- a/native/src/java_types.rs
+++ b/native/src/java_types.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use jni::bind_java_type;
 
 bind_java_type! {
@@ -17,12 +19,33 @@ bind_java_type! {
 
     methods {
         pub fn remove_buffer(),
-        pub fn set_viewport_src(x: jdouble, y: jdouble, width: jdouble, height: jdouble),
+        pub fn set_viewport_src(
+            x: jdouble,
+            y: jdouble,
+            width: jdouble,
+            height: jdouble
+        ),
         pub fn set_viewport_dst(width: jint, height: jint),
-        pub fn attach_shm_buffer(ptr: jlong, width: jint, height: jint, format: jint, stride: jint),
-        pub fn attach_single_pixel_buffer(red: jbyte, green: jbyte, blue: jbyte, alpha: jbyte),
+        pub fn attach_shm_buffer(
+            ptr: jlong,
+            width: jint,
+            height: jint,
+            format: jint,
+            stride: jint
+        ),
+        pub fn attach_single_pixel_buffer(
+            red: jbyte,
+            green: jbyte,
+            blue: jbyte,
+            alpha: jbyte
+        ),
         pub fn attach_dmabuf(handle: jlong) -> jboolean,
-        pub fn attach_new_dmabuf(dmabuf_handle: jlong, egl_image_ptr: jlong, width: jint, height: jint),
+        pub fn attach_new_dmabuf(
+            dmabuf_handle: jlong,
+            egl_image_ptr: jlong,
+            width: jint,
+            height: jint
+        ),
     },
 }
 
@@ -32,6 +55,17 @@ bind_java_type! {
     java_type = dev.evvie.waylandcraft.desktop.RawDesktopEntry,
 
     constructors {
-        fn new(app_id: JString, name: JString, generic_name: JString, exec: JString, exec_terminal: jboolean, comment: JString, keywords: JString[], categories: JString[], visible: jboolean, icon_path: JString)
+        fn new(
+            app_id: JString,
+            name: JString,
+            generic_name: JString,
+            exec: JString,
+            exec_terminal: jboolean,
+            comment: JString,
+            keywords: JString[],
+            categories: JString[],
+            visible: jboolean,
+            icon_path: JString
+        )
     },
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -47,6 +47,7 @@ use std::time::Duration;
 mod bridge;
 mod ddm;
 mod egl;
+mod java_types;
 mod output;
 mod process;
 mod seat;

--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -250,13 +250,13 @@ impl WLCSeatState {
     // Focus the pointer on the given surface and register movement
     pub fn pointer_motion_focus(
         &mut self,
-        surface: Option<WlSurface>,
+        surface: Option<&WlSurface>,
         x: f64,
         y: f64,
     ) {
         let surface = surface.filter(|s| s.is_alive());
 
-        self.pointer_focus(surface.as_ref(), x, y);
+        self.pointer_focus(surface, x, y);
         if surface.is_none() {
             return;
         }

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -27,7 +27,7 @@ import net.minecraft.util.profiling.ProfilerFiller;
 
 public class WaylandCraftBridge {
 	
-	private long wlcBridgeHandle;
+	private long instance;
 	private ArrayList<WLCToplevel> toplevels = new ArrayList<WLCToplevel>();
 	private ArrayList<WLCPopup> popups = new ArrayList<WLCPopup>();
 	private ArrayList<WLCSurface> surfaces = new ArrayList<WLCSurface>();
@@ -102,8 +102,8 @@ public class WaylandCraftBridge {
 		return null;
 	}
 	
-	private WaylandCraftBridge(long wlcBridgeHandle) {
-		this.wlcBridgeHandle = wlcBridgeHandle;
+	private WaylandCraftBridge(long instance) {
+		this.instance = instance;
 	}
 	
 	public static WaylandCraftBridge start() {
@@ -122,7 +122,7 @@ public class WaylandCraftBridge {
 		}
 		WLCToplevel toplevel = new WLCToplevel(topLevelHandle);
 		
-		long surfaceHandle = toplevelSurface(this.wlcBridgeHandle, topLevelHandle);
+		long surfaceHandle = toplevelSurface(this.instance, topLevelHandle);
 		WLCSurface surface = getOrCreateSurface(surfaceHandle);
 		toplevel.surface = surface;
 		
@@ -143,11 +143,11 @@ public class WaylandCraftBridge {
 		}
 		WLCPopup popup = new WLCPopup(handle);
 		
-		long surfaceHandle = popupSurface(this.wlcBridgeHandle, handle);
+		long surfaceHandle = popupSurface(this.instance, handle);
 		WLCSurface surface = getOrCreateSurface(surfaceHandle);
 		popup.surface = surface;
 		
-		popup.parentHandle = popupParent(this.wlcBridgeHandle, handle);
+		popup.parentHandle = popupParent(this.instance, handle);
 		
 		popups.add(popup);
 		return popup;
@@ -180,7 +180,7 @@ public class WaylandCraftBridge {
 				toplevels_new.add(toplevel);
 			}
 			else {
-				freeToplevel(this.wlcBridgeHandle, toplevel.takeHandle());
+				freeToplevel(this.instance, toplevel.takeHandle());
 			}
 		}
 		this.toplevels = toplevels_new;
@@ -193,7 +193,7 @@ public class WaylandCraftBridge {
 				popups_new.add(popup);
 			}
 			else {
-				freePopup(this.wlcBridgeHandle, popup.takeHandle());
+				freePopup(this.instance, popup.takeHandle());
 			}
 		}
 		this.popups = popups_new;
@@ -206,7 +206,7 @@ public class WaylandCraftBridge {
 				surfaces_new.add(surface);
 			}
 			else {
-				freeSurface(this.wlcBridgeHandle, surface.takeHandle());
+				freeSurface(this.instance, surface.takeHandle());
 			}
 		}
 		this.surfaces = surfaces_new;
@@ -237,30 +237,30 @@ public class WaylandCraftBridge {
 		
 		profiler.push("update");
 		// Update wayland clients
-		update(this.wlcBridgeHandle);
+		update(this.instance);
 		profiler.pop();
 		
 		// Find all available toplevels and delete ones that no longer exist
-		long[] toplevelHandles = toplevels(wlcBridgeHandle);
+		long[] toplevelHandles = toplevels(instance);
 		deleteNonExistingToplevels(toplevelHandles);
 		
 		// Find all available popups and delete ones that no longer exist
-		long[] popupHandles = popups(wlcBridgeHandle);
+		long[] popupHandles = popups(instance);
 		deleteNonExistingPopups(popupHandles);
 		
-		long[] minimizeRequests = minimizeReq(wlcBridgeHandle);
-		long[] maximizeRequests = maximizeReq(wlcBridgeHandle);
-		long[] unmaximizeRequests = unmaximizeReq(wlcBridgeHandle);
-		long[] fullscreenRequests = fullscreenReq(wlcBridgeHandle);
-		long[] unfullscreenRequests = unfullscreenReq(wlcBridgeHandle);
-		long[] fullscreened = fullscreened(wlcBridgeHandle);
+		long[] minimizeRequests = minimizeReq(instance);
+		long[] maximizeRequests = maximizeReq(instance);
+		long[] unmaximizeRequests = unmaximizeReq(instance);
+		long[] fullscreenRequests = fullscreenReq(instance);
+		long[] unfullscreenRequests = unfullscreenReq(instance);
+		long[] fullscreened = fullscreened(instance);
 		
-		int[] moveRequest = moveRequest(wlcBridgeHandle);
+		int[] moveRequest = moveRequest(instance);
 		if(moveRequest != null) {
 			lastMoveRequestSerial = moveRequest[0];
 		}
 		
-		int[] resizeRequest = resizeRequest(wlcBridgeHandle);
+		int[] resizeRequest = resizeRequest(instance);
 		if(resizeRequest != null) {
 			lastResizeRequest = new ResizeRequest(resizeRequest[0], resizeRequest[1]);
 		}
@@ -276,7 +276,7 @@ public class WaylandCraftBridge {
 		for(long handle : toplevelHandles) {
 			WLCToplevel toplevel = getOrCreateToplevel(handle);
 			WLCSurface root = toplevel.getSurfaceTree();
-			toplevel.lastChild = updateSurfaceTree(this.wlcBridgeHandle, root);
+			toplevel.lastChild = updateSurfaceTree(this.instance, root);
 			
 			updateGeometry(toplevel);
 			toplevel.title = toplevelTitle(toplevel.getHandle());
@@ -302,17 +302,17 @@ public class WaylandCraftBridge {
 			popup.offsetY = offset[1];
 			
 			WLCSurface root = popup.getSurfaceTree();
-			popup.lastChild = updateSurfaceTree(this.wlcBridgeHandle, root);
+			popup.lastChild = updateSurfaceTree(this.instance, root);
 			updateGeometry(popup);
 		}
 		
-		long dndIconHandle = dndIcon(wlcBridgeHandle);
+		long dndIconHandle = dndIcon(instance);
 		if(dndIconHandle != 0) {
 			WLCSurface dndIconSurface = getOrCreateSurface(dndIconHandle);
 			if(dndIcon != null && dndIcon.surface != dndIconSurface) dndIcon = null;
 			if(dndIcon == null) dndIcon = new IconSurface(dndIconSurface);
 			
-			updateSurfaceData(wlcBridgeHandle, dndIcon.surface);
+			updateSurfaceData(instance, dndIcon.surface);
 			dndIcon.surface.visited = true;
 		}
 		else {
@@ -339,7 +339,7 @@ public class WaylandCraftBridge {
 		for(WLCAbstractWindow window : allWindows) {
 			WLCSurface root = window.getSurfaceTree();
 			for(WLCSurface surface = root; surface != null; surface = surface.getNextChild()) {
-				updateSurfaceData(wlcBridgeHandle, surface);
+				updateSurfaceData(instance, surface);
 				calculateSubpos(surface);
 			}
 		}
@@ -383,7 +383,7 @@ public class WaylandCraftBridge {
 		dmabufs.removeAll(unusedDmabufs);
 		for(DmabufTexture dmabuf : unusedDmabufs) {
 			dmabuf.free();
-			deleteDmabuf(wlcBridgeHandle, dmabuf.handle);
+			deleteDmabuf(instance, dmabuf.handle);
 		}
 	}
 	
@@ -470,7 +470,7 @@ public class WaylandCraftBridge {
 	}
 	
 	public String getSocket() {
-		return socket(this.wlcBridgeHandle);
+		return socket(this.instance);
 	}
 	
 	public boolean inputRegionContains(WLCSurface surface, double x, double y) {
@@ -478,39 +478,39 @@ public class WaylandCraftBridge {
 	}
 	
 	public void sendMotion(double x, double y) {
-		pointerMotion(wlcBridgeHandle, x, y);
+		pointerMotion(instance, x, y);
 	}
 	
 	public void sendMotionRefocus(WLCSurface surface, double x, double y) {
-		pointerMotionFocus(wlcBridgeHandle, surface.getHandle(), x, y);
+		pointerMotionFocus(instance, surface.getHandle(), x, y);
 	}
 	
 	public void sendRelativeMotion(double dx, double dy) {
-		pointerRelMotion(wlcBridgeHandle, dx, dy);
+		pointerRelMotion(instance, dx, dy);
 	}
 	
 	public void sendMotionOutside() {
-		pointerLeave(wlcBridgeHandle);
+		pointerLeave(instance);
 	}
 	
 	public boolean maybeLockPointer(WLCSurface surface) {
-		return maybePointerLock(wlcBridgeHandle, surface.getHandle());
+		return maybePointerLock(instance, surface.getHandle());
 	}
 	
 	public void unlockPointer() {
-		pointerUnlock(wlcBridgeHandle);
+		pointerUnlock(instance);
 	}
 	
 	public int sendButton(int button, int state) {
-		return pointerButton(wlcBridgeHandle, button, state);
+		return pointerButton(instance, button, state);
 	}
 	
 	public void sendScroll(int axis, double value) {
-		pointerAxis(wlcBridgeHandle, axis, value);
+		pointerAxis(instance, axis, value);
 	}
 	
 	public CursorShape getCursorShape() {
-		return CursorShape.fromId(cursorShape(wlcBridgeHandle));
+		return CursorShape.fromId(cursorShape(instance));
 	}
 	
 	public void focusSurface(@Nullable WLCToplevel toplevel) {
@@ -519,7 +519,7 @@ public class WaylandCraftBridge {
 			handle = toplevel.getHandle();
 		}
 		
-		keyboardFocus(wlcBridgeHandle, handle);
+		keyboardFocus(instance, handle);
 		
 		// Make toplevel most recently focused
 		if(toplevel != null) {
@@ -529,11 +529,11 @@ public class WaylandCraftBridge {
 	}
 	
 	public void activateKeyboard() {
-		keyboardActivate(wlcBridgeHandle);
+		keyboardActivate(instance);
 	}
 	
 	public void deactivateKeyboard() {
-		keyboardDeactivate(wlcBridgeHandle);
+		keyboardDeactivate(instance);
 	}
 	
 	private void updateFocusOrder() {
@@ -556,15 +556,15 @@ public class WaylandCraftBridge {
 	}
 	
 	public void pressKey(int scancode) {
-		keyboardInput(wlcBridgeHandle, scancode, 1);
+		keyboardInput(instance, scancode, 1);
 	}
 	
 	public void releaseKey(int scancode) {
-		keyboardInput(wlcBridgeHandle, scancode, 0);
+		keyboardInput(instance, scancode, 0);
 	}
 	
 	public void internalKeyUpdate(int scancode, boolean pressed) {
-		keyboardUpdate(wlcBridgeHandle, scancode, pressed);
+		keyboardUpdate(instance, scancode, pressed);
 	}
 	
 	public void resizeToplevelInteractive(WLCToplevel toplevel, int width, int height) {
@@ -580,11 +580,11 @@ public class WaylandCraftBridge {
 	}
 	
 	public void maximizeToplevel(WLCToplevel toplevel) {
-		toplevelMaximize(wlcBridgeHandle, toplevel.getHandle());
+		toplevelMaximize(instance, toplevel.getHandle());
 	}
 	
 	public void fullscreenToplevel(WLCToplevel toplevel) {
-		toplevelFullscreen(wlcBridgeHandle, toplevel.getHandle());
+		toplevelFullscreen(instance, toplevel.getHandle());
 	}
 	
 	public Integer checkMoveRequest() {
@@ -602,29 +602,29 @@ public class WaylandCraftBridge {
 	}
 	
 	public void resizeOutput(int width, int height) {
-		outputResize(wlcBridgeHandle, width, height);
+		outputResize(instance, width, height);
 	}
 	
 	public void setOutputBounds(int width, int height) {
-		outputSetBounds(wlcBridgeHandle, width, height);
+		outputSetBounds(instance, width, height);
 	}
 	
 	public Size getOutputSize() {
-		int[] size = outputSize(wlcBridgeHandle);
+		int[] size = outputSize(instance);
 		return new Size(size[0], size[1]);
 	}
 	
 	public Size getOutputBounds() {
-		int[] size = outputBounds(wlcBridgeHandle);
+		int[] size = outputBounds(instance);
 		return new Size(size[0], size[1]);
 	}
 	
 	public RawDesktopEntry loadDesktopEntry(File path) {
-		return loadDesktopEntry(wlcBridgeHandle, path.getAbsolutePath());
+		return loadDesktopEntry(instance, path.getAbsolutePath());
 	}
 	
 	public RawDesktopEntry[] loadSystemDesktopEntries() {
-		return loadDesktopEntries(wlcBridgeHandle);
+		return loadDesktopEntries(instance);
 	}
 	
 	public boolean renderSVG(File file, int width, int height, long bufferPtr) {
@@ -632,38 +632,38 @@ public class WaylandCraftBridge {
 	}
 	
 	public boolean execApp(String appId) {
-		return execApp(wlcBridgeHandle, appId);
+		return execApp(instance, appId);
 	}
 	
 	public void setKeymapDefault() {
-		setKeymapDefault(wlcBridgeHandle);
+		setKeymapDefault(instance);
 	}
 	
 	public String exportKeymap() {
-		return exportKeymap(wlcBridgeHandle);
+		return exportKeymap(instance);
 	}
 	
 	public boolean setKeymapFromStr(String keymap) {
-		return setKeymapFromStr(wlcBridgeHandle, keymap);
+		return setKeymapFromStr(instance, keymap);
 	}
 	
 	public Integer checkDndRequest() {
-		int[] serial = checkDndRequest(wlcBridgeHandle);
+		int[] serial = checkDndRequest(instance);
 		if(serial == null) return null;
 		return serial[0];
 	}
 	
 	public void dndCancel() {
-		dndCancel(wlcBridgeHandle);
+		dndCancel(instance);
 	}
 	
 	public void dndDrop() {
-		dndDrop(wlcBridgeHandle);
+		dndDrop(instance);
 	}
 	
 	public void sendDndMotion(WLCSurface surface, double x, double y) {
 		long handle = surface == null ? 0 : surface.getHandle();
-		dndMotion(wlcBridgeHandle, handle, x, y);
+		dndMotion(instance, handle, x, y);
 	}
 	
 	public static record Size(int width, int height) {}
@@ -671,14 +671,14 @@ public class WaylandCraftBridge {
 	public static record ResizeRequest(int serial, int edges) {}
 	
 	private static native long init(long glfwGetProcAddress, long eglDisplay);
-	private static native void update(long wlcBridgeHandle);
-	private static native String socket(long wlcBridgeHandle);
+	private static native void update(long instance);
+	private static native String socket(long instance);
 	private static native void sendFrame(long surfaceHandle);
 	
-	private static native void updateSurfaceData(long wlcBridgeHandle, WLCSurface surface);
+	private static native void updateSurfaceData(long instance, WLCSurface surface);
 	
-	private static native long[] toplevels(long wlcBridgeHandle);
-	private static native long toplevelSurface(long wlcBridgeHandle, long topLevelHandle);
+	private static native long[] toplevels(long instance);
+	private static native long toplevelSurface(long instance, long topLevelHandle);
 	private static native String toplevelTitle(long topLevelHandle);
 	private static native String toplevelAppID(long topLevelHandle);
 	// Resize toplevel
@@ -687,32 +687,32 @@ public class WaylandCraftBridge {
 	private static native void toplevelResizeOvr(long topLevelHandle, int width, int height);
 	
 	// Collect all toplevels that have sent a minimize request and clear the list
-	private static native long[] minimizeReq(long wlcBridgeHandle);
+	private static native long[] minimizeReq(long instance);
 	// Collect all toplevels that have sent a maximize request and clear the list
-	private static native long[] maximizeReq(long wlcBridgeHandle);
+	private static native long[] maximizeReq(long instance);
 	// Collect all toplevels that have sent an unmaximize request and clear the list
-	private static native long[] unmaximizeReq(long wlcBridgeHandle);
+	private static native long[] unmaximizeReq(long instance);
 	// Collect all toplevels that have sent a fullscreen request and clear the list
-	private static native long[] fullscreenReq(long wlcBridgeHandle);
+	private static native long[] fullscreenReq(long instance);
 	// Collect all toplevels that have sent an unfullscreen request and clear the list
-	private static native long[] unfullscreenReq(long wlcBridgeHandle);
+	private static native long[] unfullscreenReq(long instance);
 	
 	// Collect up to one serial of a sent interactive move request
-	private static native int[] moveRequest(long wlcBridgeHandle);
+	private static native int[] moveRequest(long instance);
 	// Collect up to one serial of a sent interactive resize request
-	private static native int[] resizeRequest(long wlcBridgeHandle);
+	private static native int[] resizeRequest(long instance);
 	
 	// All toplevels that are currently in fullscreen
-	private static native long[] fullscreened(long wlcBridgeHandle);
+	private static native long[] fullscreened(long instance);
 	
-	private static native void toplevelMaximize(long wlcBridgeHandle, long topLevelHandle);
-	private static native void toplevelFullscreen(long wlcBridgeHandle, long topLevelHandle);
+	private static native void toplevelMaximize(long instance, long topLevelHandle);
+	private static native void toplevelFullscreen(long instance, long topLevelHandle);
 	
-	private static native long[] popups(long wlcBridgeHandle);
-	private static native long popupSurface(long wlcBridgeHandle, long topLevelHandle);
+	private static native long[] popups(long instance);
+	private static native long popupSurface(long instance, long topLevelHandle);
 	// Query the parent of a popup
 	// Returned handle is a handle either to a toplevel or another popup
-	private static native long popupParent(long wlcBridgeHandle, long topLevelHandle);
+	private static native long popupParent(long instance, long topLevelHandle);
 	// Query popup local offset coordinates
 	// Returns two-element list containing x,y
 	private static native int[] popupOffset(long popupHandle);
@@ -723,82 +723,82 @@ public class WaylandCraftBridge {
 	private static native int[] surfaceXDGGeometry(long surfaceHandle);
 	
 	// Release a dmabuf wl_buffer
-	private static native void deleteDmabuf(long wlcBridgeHandle, long dmabufHandle);
+	private static native void deleteDmabuf(long instance, long dmabufHandle);
 	
 	// Updates the surface tree given by the root surface
 	// This changes the doubly linked list of the WLCSurfaces.
 	// The returned surface is the last (most deeply nested) child
-	private native WLCSurface updateSurfaceTree(long wlcBridgeHandle, WLCSurface root);
+	private native WLCSurface updateSurfaceTree(long instance, WLCSurface root);
 	
 	// Check if point in surface input region
 	private static native boolean checkInputRegion(long surfaceHandle, double x, double y);
 	
 	// Create pointer motion event
-	private static native void pointerMotion(long wlcBridgeHandle, double x, double y);
+	private static native void pointerMotion(long instance, double x, double y);
 	
 	// Create pointer motion event
-	private static native void pointerMotionFocus(long wlcBridgeHandle, long surfaceHandle, double x, double y);
+	private static native void pointerMotionFocus(long instance, long surfaceHandle, double x, double y);
 	
 	// Send relative pointer motion to surface with pointer focus
-	private static native void pointerRelMotion(long wlcBridgeHandle, double dx, double dy);
+	private static native void pointerRelMotion(long instance, double dx, double dy);
 	
-	private static native boolean maybePointerLock(long wlcBridgeHandle, long surfaceHandle);
+	private static native boolean maybePointerLock(long instance, long surfaceHandle);
 	
-	private static native void pointerUnlock(long wlcBridgeHandle);
+	private static native void pointerUnlock(long instance);
 	
 	// Remove pointer focus from all surfaces
-	private static native void pointerLeave(long wlcBridgeHandle);
+	private static native void pointerLeave(long instance);
 	
 	// Create pointer button event. `button` has to be the linux button code, state is 1 for pressed, 0 for released
-	private static native int pointerButton(long wlcBridgeHandle, int button, int state);
+	private static native int pointerButton(long instance, int button, int state);
 	
 	// Create pointer axis event. `axis` is the scroll axis (0 for vertical, 1 for horizontal)
-	private static native void pointerAxis(long wlcBridgeHandle, int axis, double value);
+	private static native void pointerAxis(long instance, int axis, double value);
 	
 	// Get active cursor image
-	private static native int cursorShape(long wlcBridgeHandle);
+	private static native int cursorShape(long instance);
 	
 	// Set keyboard focus to a wayland surface. The handle may be 0 to unfocus any surfaces
-	private static native void keyboardFocus(long wlcBridgeHandle, long surfaceHandle);
+	private static native void keyboardFocus(long instance, long surfaceHandle);
 	
-	private static native void keyboardActivate(long wlcBridgeHandle);
-	private static native void keyboardDeactivate(long wlcBridgeHandle);
+	private static native void keyboardActivate(long instance);
+	private static native void keyboardDeactivate(long instance);
 	
 	// Keyboard input. scancode is the raw keycode. action: 0 is released, 1 is pressed.
-	private static native void keyboardInput(long wlcBridgeHandle, int scancode, int action);
+	private static native void keyboardInput(long instance, int scancode, int action);
 	
 	// Update internal key state
-	private static native void keyboardUpdate(long wlcBridgeHandle, int scancode, boolean pressed);
+	private static native void keyboardUpdate(long instance, int scancode, boolean pressed);
 	
-	private static native int[] outputSize(long wlcBridgeHandle);
-	private static native int[] outputBounds(long wlcBridgeHandle);
+	private static native int[] outputSize(long instance);
+	private static native int[] outputBounds(long instance);
 	
 	// Update virtual output dimensions
-	private static native void outputResize(long wlcBridgeHandle, int width, int height);
+	private static native void outputResize(long instance, int width, int height);
 	
 	// Update virtual output maximum window bounds
-	private static native void outputSetBounds(long wlcBridgeHandle, int width, int height);
+	private static native void outputSetBounds(long instance, int width, int height);
 	
-	private static native void freeSurface(long wlcBridgeHandle, long surfaceHandle);
-	private static native void freeToplevel(long wlcBridgeHandle, long toplevelHandle);
-	private static native void freePopup(long wlcBridgeHandle, long popupHandle);
+	private static native void freeSurface(long instance, long surfaceHandle);
+	private static native void freeToplevel(long instance, long toplevelHandle);
+	private static native void freePopup(long instance, long popupHandle);
 	
-	private static native RawDesktopEntry loadDesktopEntry(long wlcBridgeHandle, String path);
-	private static native RawDesktopEntry[] loadDesktopEntries(long wlcBridgeHandle);
+	private static native RawDesktopEntry loadDesktopEntry(long instance, String path);
+	private static native RawDesktopEntry[] loadDesktopEntries(long instance);
 	
 	private static native boolean renderSVG(String path, int width, int height, long bufferPtr);
 	
-	private static native boolean execApp(long wlcBridgeHandle, String appId);
+	private static native boolean execApp(long instance, String appId);
 	
-	private static native void setKeymapDefault(long wlcBridgeHandle);
-	private static native String exportKeymap(long wlcBridgeHandle);
-	private static native boolean setKeymapFromStr(long wlcBridgeHandle, String keymap);
+	private static native void setKeymapDefault(long instance);
+	private static native String exportKeymap(long instance);
+	private static native boolean setKeymapFromStr(long instance, String keymap);
 	
-	private static native int[] checkDndRequest(long wlcBridgeHandle);
-	private static native boolean checkDndActive(long wlcBridgeHandle);
-	private static native void dndCancel(long wlcBridgeHandle);
-	private static native void dndDrop(long wlcBridgeHandle);
-	private static native void dndMotion(long wlcBridgeHandle, long surfaceHandle, double x, double y);
-	private static native long dndIcon(long wlcBridgeHandle);
+	private static native int[] checkDndRequest(long instance);
+	private static native boolean checkDndActive(long instance);
+	private static native void dndCancel(long instance);
+	private static native void dndDrop(long instance);
+	private static native void dndMotion(long instance, long surfaceHandle, double x, double y);
+	private static native long dndIcon(long instance);
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -27,7 +27,7 @@ import net.minecraft.util.profiling.ProfilerFiller;
 
 public class WaylandCraftBridge {
 	
-	private long instance;
+	private long wlcBridgeHandle;
 	private ArrayList<WLCToplevel> toplevels = new ArrayList<WLCToplevel>();
 	private ArrayList<WLCPopup> popups = new ArrayList<WLCPopup>();
 	private ArrayList<WLCSurface> surfaces = new ArrayList<WLCSurface>();
@@ -102,8 +102,8 @@ public class WaylandCraftBridge {
 		return null;
 	}
 	
-	private WaylandCraftBridge(long handle) {
-		this.instance = handle;
+	private WaylandCraftBridge(long wlcBridgeHandle) {
+		this.wlcBridgeHandle = wlcBridgeHandle;
 	}
 	
 	public static WaylandCraftBridge start() {
@@ -116,13 +116,13 @@ public class WaylandCraftBridge {
 		return new WaylandCraftBridge(handle);
 	}
 	
-	protected WLCToplevel getOrCreateToplevel(long handle) {
+	protected WLCToplevel getOrCreateToplevel(long topLevelHandle) {
 		for(WLCToplevel toplevel : toplevels) {
-			if(toplevel.getHandle() == handle) return toplevel;
+			if(toplevel.getHandle() == topLevelHandle) return toplevel;
 		}
-		WLCToplevel toplevel = new WLCToplevel(handle);
+		WLCToplevel toplevel = new WLCToplevel(topLevelHandle);
 		
-		long surfaceHandle = toplevelSurface(this.instance, handle);
+		long surfaceHandle = toplevelSurface(this.wlcBridgeHandle, topLevelHandle);
 		WLCSurface surface = getOrCreateSurface(surfaceHandle);
 		toplevel.surface = surface;
 		
@@ -143,11 +143,11 @@ public class WaylandCraftBridge {
 		}
 		WLCPopup popup = new WLCPopup(handle);
 		
-		long surfaceHandle = popupSurface(this.instance, handle);
+		long surfaceHandle = popupSurface(this.wlcBridgeHandle, handle);
 		WLCSurface surface = getOrCreateSurface(surfaceHandle);
 		popup.surface = surface;
 		
-		popup.parentHandle = popupParent(this.instance, handle);
+		popup.parentHandle = popupParent(this.wlcBridgeHandle, handle);
 		
 		popups.add(popup);
 		return popup;
@@ -180,7 +180,7 @@ public class WaylandCraftBridge {
 				toplevels_new.add(toplevel);
 			}
 			else {
-				freeToplevel(this.instance, toplevel.takeHandle());
+				freeToplevel(this.wlcBridgeHandle, toplevel.takeHandle());
 			}
 		}
 		this.toplevels = toplevels_new;
@@ -193,7 +193,7 @@ public class WaylandCraftBridge {
 				popups_new.add(popup);
 			}
 			else {
-				freePopup(this.instance, popup.takeHandle());
+				freePopup(this.wlcBridgeHandle, popup.takeHandle());
 			}
 		}
 		this.popups = popups_new;
@@ -206,7 +206,7 @@ public class WaylandCraftBridge {
 				surfaces_new.add(surface);
 			}
 			else {
-				freeSurface(this.instance, surface.takeHandle());
+				freeSurface(this.wlcBridgeHandle, surface.takeHandle());
 			}
 		}
 		this.surfaces = surfaces_new;
@@ -237,30 +237,30 @@ public class WaylandCraftBridge {
 		
 		profiler.push("update");
 		// Update wayland clients
-		update(this.instance);
+		update(this.wlcBridgeHandle);
 		profiler.pop();
 		
 		// Find all available toplevels and delete ones that no longer exist
-		long[] toplevelHandles = toplevels(instance);
+		long[] toplevelHandles = toplevels(wlcBridgeHandle);
 		deleteNonExistingToplevels(toplevelHandles);
 		
 		// Find all available popups and delete ones that no longer exist
-		long[] popupHandles = popups(instance);
+		long[] popupHandles = popups(wlcBridgeHandle);
 		deleteNonExistingPopups(popupHandles);
 		
-		long[] minimizeRequests = minimizeReq(instance);
-		long[] maximizeRequests = maximizeReq(instance);
-		long[] unmaximizeRequests = unmaximizeReq(instance);
-		long[] fullscreenRequests = fullscreenReq(instance);
-		long[] unfullscreenRequests = unfullscreenReq(instance);
-		long[] fullscreened = fullscreened(instance);
+		long[] minimizeRequests = minimizeReq(wlcBridgeHandle);
+		long[] maximizeRequests = maximizeReq(wlcBridgeHandle);
+		long[] unmaximizeRequests = unmaximizeReq(wlcBridgeHandle);
+		long[] fullscreenRequests = fullscreenReq(wlcBridgeHandle);
+		long[] unfullscreenRequests = unfullscreenReq(wlcBridgeHandle);
+		long[] fullscreened = fullscreened(wlcBridgeHandle);
 		
-		int[] moveRequest = moveRequest(instance);
+		int[] moveRequest = moveRequest(wlcBridgeHandle);
 		if(moveRequest != null) {
 			lastMoveRequestSerial = moveRequest[0];
 		}
 		
-		int[] resizeRequest = resizeRequest(instance);
+		int[] resizeRequest = resizeRequest(wlcBridgeHandle);
 		if(resizeRequest != null) {
 			lastResizeRequest = new ResizeRequest(resizeRequest[0], resizeRequest[1]);
 		}
@@ -276,7 +276,7 @@ public class WaylandCraftBridge {
 		for(long handle : toplevelHandles) {
 			WLCToplevel toplevel = getOrCreateToplevel(handle);
 			WLCSurface root = toplevel.getSurfaceTree();
-			toplevel.lastChild = updateSurfaceTree(root);
+			toplevel.lastChild = updateSurfaceTree(this.wlcBridgeHandle, root);
 			
 			updateGeometry(toplevel);
 			toplevel.title = toplevelTitle(toplevel.getHandle());
@@ -302,17 +302,17 @@ public class WaylandCraftBridge {
 			popup.offsetY = offset[1];
 			
 			WLCSurface root = popup.getSurfaceTree();
-			popup.lastChild = updateSurfaceTree(root);
+			popup.lastChild = updateSurfaceTree(this.wlcBridgeHandle, root);
 			updateGeometry(popup);
 		}
 		
-		long dndIconHandle = dndIcon(instance);
+		long dndIconHandle = dndIcon(wlcBridgeHandle);
 		if(dndIconHandle != 0) {
 			WLCSurface dndIconSurface = getOrCreateSurface(dndIconHandle);
 			if(dndIcon != null && dndIcon.surface != dndIconSurface) dndIcon = null;
 			if(dndIcon == null) dndIcon = new IconSurface(dndIconSurface);
 			
-			updateSurfaceData(instance, dndIcon.surface);
+			updateSurfaceData(wlcBridgeHandle, dndIcon.surface);
 			dndIcon.surface.visited = true;
 		}
 		else {
@@ -339,7 +339,7 @@ public class WaylandCraftBridge {
 		for(WLCAbstractWindow window : allWindows) {
 			WLCSurface root = window.getSurfaceTree();
 			for(WLCSurface surface = root; surface != null; surface = surface.getNextChild()) {
-				updateSurfaceData(instance, surface);
+				updateSurfaceData(wlcBridgeHandle, surface);
 				calculateSubpos(surface);
 			}
 		}
@@ -383,7 +383,7 @@ public class WaylandCraftBridge {
 		dmabufs.removeAll(unusedDmabufs);
 		for(DmabufTexture dmabuf : unusedDmabufs) {
 			dmabuf.free();
-			deleteDmabuf(instance, dmabuf.handle);
+			deleteDmabuf(wlcBridgeHandle, dmabuf.handle);
 		}
 	}
 	
@@ -470,7 +470,7 @@ public class WaylandCraftBridge {
 	}
 	
 	public String getSocket() {
-		return socket(this.instance);
+		return socket(this.wlcBridgeHandle);
 	}
 	
 	public boolean inputRegionContains(WLCSurface surface, double x, double y) {
@@ -478,39 +478,39 @@ public class WaylandCraftBridge {
 	}
 	
 	public void sendMotion(double x, double y) {
-		pointerMotion(instance, x, y);
+		pointerMotion(wlcBridgeHandle, x, y);
 	}
 	
 	public void sendMotionRefocus(WLCSurface surface, double x, double y) {
-		pointerMotionFocus(instance, surface.getHandle(), x, y);
+		pointerMotionFocus(wlcBridgeHandle, surface.getHandle(), x, y);
 	}
 	
 	public void sendRelativeMotion(double dx, double dy) {
-		pointerRelMotion(instance, dx, dy);
+		pointerRelMotion(wlcBridgeHandle, dx, dy);
 	}
 	
 	public void sendMotionOutside() {
-		pointerLeave(instance);
+		pointerLeave(wlcBridgeHandle);
 	}
 	
 	public boolean maybeLockPointer(WLCSurface surface) {
-		return maybePointerLock(instance, surface.getHandle());
+		return maybePointerLock(wlcBridgeHandle, surface.getHandle());
 	}
 	
 	public void unlockPointer() {
-		pointerUnlock(instance);
+		pointerUnlock(wlcBridgeHandle);
 	}
 	
 	public int sendButton(int button, int state) {
-		return pointerButton(instance, button, state);
+		return pointerButton(wlcBridgeHandle, button, state);
 	}
 	
 	public void sendScroll(int axis, double value) {
-		pointerAxis(instance, axis, value);
+		pointerAxis(wlcBridgeHandle, axis, value);
 	}
 	
 	public CursorShape getCursorShape() {
-		return CursorShape.fromId(cursorShape(instance));
+		return CursorShape.fromId(cursorShape(wlcBridgeHandle));
 	}
 	
 	public void focusSurface(@Nullable WLCToplevel toplevel) {
@@ -519,7 +519,7 @@ public class WaylandCraftBridge {
 			handle = toplevel.getHandle();
 		}
 		
-		keyboardFocus(instance, handle);
+		keyboardFocus(wlcBridgeHandle, handle);
 		
 		// Make toplevel most recently focused
 		if(toplevel != null) {
@@ -529,11 +529,11 @@ public class WaylandCraftBridge {
 	}
 	
 	public void activateKeyboard() {
-		keyboardActivate(instance);
+		keyboardActivate(wlcBridgeHandle);
 	}
 	
 	public void deactivateKeyboard() {
-		keyboardDeactivate(instance);
+		keyboardDeactivate(wlcBridgeHandle);
 	}
 	
 	private void updateFocusOrder() {
@@ -556,15 +556,15 @@ public class WaylandCraftBridge {
 	}
 	
 	public void pressKey(int scancode) {
-		keyboardInput(instance, scancode, 1);
+		keyboardInput(wlcBridgeHandle, scancode, 1);
 	}
 	
 	public void releaseKey(int scancode) {
-		keyboardInput(instance, scancode, 0);
+		keyboardInput(wlcBridgeHandle, scancode, 0);
 	}
 	
 	public void internalKeyUpdate(int scancode, boolean pressed) {
-		keyboardUpdate(instance, scancode, pressed);
+		keyboardUpdate(wlcBridgeHandle, scancode, pressed);
 	}
 	
 	public void resizeToplevelInteractive(WLCToplevel toplevel, int width, int height) {
@@ -580,11 +580,11 @@ public class WaylandCraftBridge {
 	}
 	
 	public void maximizeToplevel(WLCToplevel toplevel) {
-		toplevelMaximize(instance, toplevel.getHandle());
+		toplevelMaximize(wlcBridgeHandle, toplevel.getHandle());
 	}
 	
 	public void fullscreenToplevel(WLCToplevel toplevel) {
-		toplevelFullscreen(instance, toplevel.getHandle());
+		toplevelFullscreen(wlcBridgeHandle, toplevel.getHandle());
 	}
 	
 	public Integer checkMoveRequest() {
@@ -602,68 +602,68 @@ public class WaylandCraftBridge {
 	}
 	
 	public void resizeOutput(int width, int height) {
-		outputResize(instance, width, height);
+		outputResize(wlcBridgeHandle, width, height);
 	}
 	
 	public void setOutputBounds(int width, int height) {
-		outputSetBounds(instance, width, height);
+		outputSetBounds(wlcBridgeHandle, width, height);
 	}
 	
 	public Size getOutputSize() {
-		int[] size = outputSize(instance);
+		int[] size = outputSize(wlcBridgeHandle);
 		return new Size(size[0], size[1]);
 	}
 	
 	public Size getOutputBounds() {
-		int[] size = outputBounds(instance);
+		int[] size = outputBounds(wlcBridgeHandle);
 		return new Size(size[0], size[1]);
 	}
 	
 	public RawDesktopEntry loadDesktopEntry(File path) {
-		return loadDesktopEntry(instance, path.getAbsolutePath());
+		return loadDesktopEntry(wlcBridgeHandle, path.getAbsolutePath());
 	}
 	
 	public RawDesktopEntry[] loadSystemDesktopEntries() {
-		return loadDesktopEntries(instance);
+		return loadDesktopEntries(wlcBridgeHandle);
 	}
 	
-	public boolean renderSVG(File file, int width, int height, long ptr) {
-		return renderSVG(file.getAbsolutePath(), width, height, ptr);
+	public boolean renderSVG(File file, int width, int height, long bufferPtr) {
+		return renderSVG(file.getAbsolutePath(), width, height, bufferPtr);
 	}
 	
 	public boolean execApp(String appId) {
-		return execApp(instance, appId);
+		return execApp(wlcBridgeHandle, appId);
 	}
 	
 	public void setKeymapDefault() {
-		setKeymapDefault(instance);
+		setKeymapDefault(wlcBridgeHandle);
 	}
 	
 	public String exportKeymap() {
-		return exportKeymap(instance);
+		return exportKeymap(wlcBridgeHandle);
 	}
 	
 	public boolean setKeymapFromStr(String keymap) {
-		return setKeymapFromStr(instance, keymap);
+		return setKeymapFromStr(wlcBridgeHandle, keymap);
 	}
 	
 	public Integer checkDndRequest() {
-		int[] serial = checkDndRequest(instance);
+		int[] serial = checkDndRequest(wlcBridgeHandle);
 		if(serial == null) return null;
 		return serial[0];
 	}
 	
 	public void dndCancel() {
-		dndCancel(instance);
+		dndCancel(wlcBridgeHandle);
 	}
 	
 	public void dndDrop() {
-		dndDrop(instance);
+		dndDrop(wlcBridgeHandle);
 	}
 	
 	public void sendDndMotion(WLCSurface surface, double x, double y) {
 		long handle = surface == null ? 0 : surface.getHandle();
-		dndMotion(instance, handle, x, y);
+		dndMotion(wlcBridgeHandle, handle, x, y);
 	}
 	
 	public static record Size(int width, int height) {}
@@ -671,134 +671,134 @@ public class WaylandCraftBridge {
 	public static record ResizeRequest(int serial, int edges) {}
 	
 	private static native long init(long glfwGetProcAddress, long eglDisplay);
-	private static native void update(long instance);
-	private static native String socket(long instance);
-	private static native void sendFrame(long handle);
+	private static native void update(long wlcBridgeHandle);
+	private static native String socket(long wlcBridgeHandle);
+	private static native void sendFrame(long surfaceHandle);
 	
-	private static native void updateSurfaceData(long instance, WLCSurface surface);
+	private static native void updateSurfaceData(long wlcBridgeHandle, WLCSurface surface);
 	
-	private static native long[] toplevels(long instance);
-	private static native long toplevelSurface(long instance, long handle);
-	private static native String toplevelTitle(long handle);
-	private static native String toplevelAppID(long handle);
+	private static native long[] toplevels(long wlcBridgeHandle);
+	private static native long toplevelSurface(long wlcBridgeHandle, long topLevelHandle);
+	private static native String toplevelTitle(long topLevelHandle);
+	private static native String toplevelAppID(long topLevelHandle);
 	// Resize toplevel
-	private static native void toplevelResize(long handle, int width, int height, boolean interactive);
+	private static native void toplevelResize(long topLevelHandle, int width, int height, boolean interactive);
 	// Resize toplevel override, keep maximized and fullscreen state, stop interactive resize
-	private static native void toplevelResizeOvr(long handle, int width, int height);
+	private static native void toplevelResizeOvr(long topLevelHandle, int width, int height);
 	
 	// Collect all toplevels that have sent a minimize request and clear the list
-	private static native long[] minimizeReq(long instance);
+	private static native long[] minimizeReq(long wlcBridgeHandle);
 	// Collect all toplevels that have sent a maximize request and clear the list
-	private static native long[] maximizeReq(long instance);
+	private static native long[] maximizeReq(long wlcBridgeHandle);
 	// Collect all toplevels that have sent an unmaximize request and clear the list
-	private static native long[] unmaximizeReq(long instance);
+	private static native long[] unmaximizeReq(long wlcBridgeHandle);
 	// Collect all toplevels that have sent a fullscreen request and clear the list
-	private static native long[] fullscreenReq(long instance);
+	private static native long[] fullscreenReq(long wlcBridgeHandle);
 	// Collect all toplevels that have sent an unfullscreen request and clear the list
-	private static native long[] unfullscreenReq(long instance);
+	private static native long[] unfullscreenReq(long wlcBridgeHandle);
 	
 	// Collect up to one serial of a sent interactive move request
-	private static native int[] moveRequest(long instance);
+	private static native int[] moveRequest(long wlcBridgeHandle);
 	// Collect up to one serial of a sent interactive resize request
-	private static native int[] resizeRequest(long instance);
+	private static native int[] resizeRequest(long wlcBridgeHandle);
 	
 	// All toplevels that are currently in fullscreen
-	private static native long[] fullscreened(long instance);
+	private static native long[] fullscreened(long wlcBridgeHandle);
 	
-	private static native void toplevelMaximize(long instance, long handle);
-	private static native void toplevelFullscreen(long instance, long handle);
+	private static native void toplevelMaximize(long wlcBridgeHandle, long topLevelHandle);
+	private static native void toplevelFullscreen(long wlcBridgeHandle, long topLevelHandle);
 	
-	private static native long[] popups(long instance);
-	private static native long popupSurface(long instance, long handle);
+	private static native long[] popups(long wlcBridgeHandle);
+	private static native long popupSurface(long wlcBridgeHandle, long topLevelHandle);
 	// Query the parent of a popup
 	// Returned handle is a handle either to a toplevel or another popup
-	private static native long popupParent(long instance, long handle);
+	private static native long popupParent(long wlcBridgeHandle, long topLevelHandle);
 	// Query popup local offset coordinates
 	// Returns two-element list containing x,y
-	private static native int[] popupOffset(long handle);
+	private static native int[] popupOffset(long popupHandle);
 	
 	// Query the xdg_surface window geometry of a toplevel or popup.
 	// handle should be the handle to the root WLCSurface
 	// Returns four-element array containing x,y,width,height which could be null
-	private static native int[] surfaceXDGGeometry(long handle);
+	private static native int[] surfaceXDGGeometry(long surfaceHandle);
 	
 	// Release a dmabuf wl_buffer
-	private static native void deleteDmabuf(long instance, long handle);
+	private static native void deleteDmabuf(long wlcBridgeHandle, long dmabufHandle);
 	
 	// Updates the surface tree given by the root surface
 	// This changes the doubly linked list of the WLCSurfaces.
 	// The returned surface is the last (most deeply nested) child
-	private native WLCSurface updateSurfaceTree(WLCSurface root);
+	private native WLCSurface updateSurfaceTree(long wlcBridgeHandle, WLCSurface root);
 	
 	// Check if point in surface input region
 	private static native boolean checkInputRegion(long surfaceHandle, double x, double y);
 	
 	// Create pointer motion event
-	private static native void pointerMotion(long instance, double x, double y);
+	private static native void pointerMotion(long wlcBridgeHandle, double x, double y);
 	
 	// Create pointer motion event
-	private static native void pointerMotionFocus(long instance, long handle, double x, double y);
+	private static native void pointerMotionFocus(long wlcBridgeHandle, long surfaceHandle, double x, double y);
 	
 	// Send relative pointer motion to surface with pointer focus
-	private static native void pointerRelMotion(long instance, double dx, double dy);
+	private static native void pointerRelMotion(long wlcBridgeHandle, double dx, double dy);
 	
-	private static native boolean maybePointerLock(long instance, long handle);
+	private static native boolean maybePointerLock(long wlcBridgeHandle, long surfaceHandle);
 	
-	private static native void pointerUnlock(long instance);
+	private static native void pointerUnlock(long wlcBridgeHandle);
 	
 	// Remove pointer focus from all surfaces
-	private static native void pointerLeave(long instance);
+	private static native void pointerLeave(long wlcBridgeHandle);
 	
 	// Create pointer button event. `button` has to be the linux button code, state is 1 for pressed, 0 for released
-	private static native int pointerButton(long instance, int button, int state);
+	private static native int pointerButton(long wlcBridgeHandle, int button, int state);
 	
 	// Create pointer axis event. `axis` is the scroll axis (0 for vertical, 1 for horizontal)
-	private static native void pointerAxis(long instance, int axis, double value);
+	private static native void pointerAxis(long wlcBridgeHandle, int axis, double value);
 	
 	// Get active cursor image
-	private static native int cursorShape(long instance);
+	private static native int cursorShape(long wlcBridgeHandle);
 	
 	// Set keyboard focus to a wayland surface. The handle may be 0 to unfocus any surfaces
-	private static native void keyboardFocus(long instance, long surfaceHandle);
+	private static native void keyboardFocus(long wlcBridgeHandle, long surfaceHandle);
 	
-	private static native void keyboardActivate(long instance);
-	private static native void keyboardDeactivate(long instance);
+	private static native void keyboardActivate(long wlcBridgeHandle);
+	private static native void keyboardDeactivate(long wlcBridgeHandle);
 	
 	// Keyboard input. scancode is the raw keycode. action: 0 is released, 1 is pressed.
-	private static native void keyboardInput(long instance, int scancode, int action);
+	private static native void keyboardInput(long wlcBridgeHandle, int scancode, int action);
 	
 	// Update internal key state
-	private static native void keyboardUpdate(long instance, int scancode, boolean pressed);
+	private static native void keyboardUpdate(long wlcBridgeHandle, int scancode, boolean pressed);
 	
-	private static native int[] outputSize(long instance);
-	private static native int[] outputBounds(long instance);
+	private static native int[] outputSize(long wlcBridgeHandle);
+	private static native int[] outputBounds(long wlcBridgeHandle);
 	
 	// Update virtual output dimensions
-	private static native void outputResize(long instance, int width, int height);
+	private static native void outputResize(long wlcBridgeHandle, int width, int height);
 	
 	// Update virtual output maximum window bounds
-	private static native void outputSetBounds(long instance, int width, int height);
+	private static native void outputSetBounds(long wlcBridgeHandle, int width, int height);
 	
-	private static native void freeSurface(long instance, long handle);
-	private static native void freeToplevel(long instance, long handle);
-	private static native void freePopup(long instance, long handle);
+	private static native void freeSurface(long wlcBridgeHandle, long surfaceHandle);
+	private static native void freeToplevel(long wlcBridgeHandle, long toplevelHandle);
+	private static native void freePopup(long wlcBridgeHandle, long popupHandle);
 	
-	private static native RawDesktopEntry loadDesktopEntry(long instance, String path);
-	private static native RawDesktopEntry[] loadDesktopEntries(long instance);
+	private static native RawDesktopEntry loadDesktopEntry(long wlcBridgeHandle, String path);
+	private static native RawDesktopEntry[] loadDesktopEntries(long wlcBridgeHandle);
 	
-	private static native boolean renderSVG(String path, int width, int height, long ptr);
+	private static native boolean renderSVG(String path, int width, int height, long bufferPtr);
 	
-	private static native boolean execApp(long instance, String appId);
+	private static native boolean execApp(long wlcBridgeHandle, String appId);
 	
-	private static native void setKeymapDefault(long instance);
-	private static native String exportKeymap(long instance);
-	private static native boolean setKeymapFromStr(long instance, String keymap);
+	private static native void setKeymapDefault(long wlcBridgeHandle);
+	private static native String exportKeymap(long wlcBridgeHandle);
+	private static native boolean setKeymapFromStr(long wlcBridgeHandle, String keymap);
 	
-	private static native int[] checkDndRequest(long instance);
-	private static native boolean checkDndActive(long instance);
-	private static native void dndCancel(long instance);
-	private static native void dndDrop(long instance);
-	private static native void dndMotion(long instance, long surface, double x, double y);
-	private static native long dndIcon(long instance);
+	private static native int[] checkDndRequest(long wlcBridgeHandle);
+	private static native boolean checkDndActive(long wlcBridgeHandle);
+	private static native void dndCancel(long wlcBridgeHandle);
+	private static native void dndDrop(long wlcBridgeHandle);
+	private static native void dndMotion(long wlcBridgeHandle, long surfaceHandle, double x, double y);
+	private static native long dndIcon(long wlcBridgeHandle);
 	
 }


### PR DESCRIPTION
Basic port of the bridge code to the `0.22` release(s) of `jni` and to use the new `bind_java_type` macro.

This PR is more or less of a POC. Performance *may* be worse since every native method calls back to get the WLC pointer handle instead of it being passed by value in every function, but this was just a stylistic choice and could be easily reverted (I also haven't done any profiling so who knows!). It also crashed once in the `check_input_region` method from being called with a null surface pointer when I exited a minecraft instance running under WLC.

This is also my first time using the `jni` crate so no doubt the code could be improved. If you don't like the whole change list, feel free to pick out any parts you may like.