### PR TITLE
Make windows able to snap to blocks when moving

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -80,6 +80,8 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 	public KeyMapping keyOpenScreen;
 	public KeyMapping keyOpenAppLauncher;
 	public KeyMapping keyCaptureKeyboard;
+	public KeyMapping keyRotateWindowLeft;
+	public KeyMapping keyRotateWindowRight;
 	
 	public WindowInHandRenderer windowInHandRenderer = new WindowInHandRenderer();
 	public WindowInItemFrameRenderer windowInItemFrameRenderer = new WindowInItemFrameRenderer();
@@ -113,6 +115,8 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		keyOpenScreen = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.windowManager", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_B, KEYBIND_CATEGORY));
 		keyOpenAppLauncher = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.appLauncher", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_V, KEYBIND_CATEGORY));
 		keyCaptureKeyboard = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.captureKeyboard", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_G, KEYBIND_CATEGORY));
+		keyRotateWindowLeft = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.rotateWindowLeft", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_BRACKET, KEYBIND_CATEGORY));
+		keyRotateWindowRight = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.rotateWindowRight", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_RIGHT_BRACKET, KEYBIND_CATEGORY));
 		
 		LevelRenderEvents.COLLECT_SUBMITS.register(this::renderWorld);
 		LevelRenderEvents.END_EXTRACTION.register(this::updateWorld);

--- a/src/main/java/dev/evvie/waylandcraft/grabs/MoveGrab.java
+++ b/src/main/java/dev/evvie/waylandcraft/grabs/MoveGrab.java
@@ -43,8 +43,6 @@ public class MoveGrab extends PointerGrab {
 	public void moveWorld(Vec3 pos, Vec3 view, Vec3 up) throws GrabDroppedException {
 		if(!window.isValid()) this.drop();
 		wlc.cursorShape = CursorShape.ALL_RESIZE;
-
-		// i cant believe i went out of my way to lower the amount of variables here for this basic stuff
 		if (Minecraft.getInstance().options.keyShift.isDown()) {
 			if (wlc.keyRotateWindowLeft.isDown() && !lastRotateState[0]) {
 				rotationAngle -= 45.0f;
@@ -55,7 +53,7 @@ public class MoveGrab extends PointerGrab {
 		} 
 		lastRotateState[0] = wlc.keyRotateWindowLeft.isDown();
 		lastRotateState[1] = wlc.keyRotateWindowRight.isDown();
-		Vec3 to = pos.add(view.scale(Minecraft.getInstance().player.blockInteractionRange()*2)); // i see no problem with multiplying it by 2
+		Vec3 to = pos.add(view.scale(Minecraft.getInstance().player.blockInteractionRange()*2));
 		BlockHitResult blockHit = Minecraft.getInstance().level.clip(
 			new ClipContext(
 				pos,
@@ -65,16 +63,16 @@ public class MoveGrab extends PointerGrab {
 				Minecraft.getInstance().player
 			)
 		);
-		if (Minecraft.getInstance().options.keyShift.isDown()) { // this seemed like a better way to do it till i uhm... did it..
+		if (Minecraft.getInstance().options.keyShift.isDown()) {
 			if(blockHit.getType() == BlockHitResult.Type.BLOCK) {
 				Vec3 faceDir = new Vec3(blockHit.getDirection().getStepX(), blockHit.getDirection().getStepY(), blockHit.getDirection().getStepZ());
 				lPos = blockHit.getBlockPos().getCenter().add(faceDir.scale(2.55));
-				lView = faceDir.reverse(); // if only all code was like this
+				lView = faceDir.reverse();
 
-				if (Math.abs(faceDir.y) > 0.5) { // is the window at the bottom or top of a block
+				if (Math.abs(faceDir.y) > 0.5) { // is the window facing up or down
 					lUp = new Vec3(Math.sin(Math.toRadians(rotationAngle)), 0, Math.cos(Math.toRadians(rotationAngle)));
 				} else {
-					lUp = new Vec3(0, 1, 0); // nu uh you dont get to rotate
+					lUp = new Vec3(0, 1, 0);
 					rotationAngle = 0.0f;
 				}
 
@@ -83,7 +81,7 @@ public class MoveGrab extends PointerGrab {
 			} else {
 				this.init();
 				lPos = pos.add(view.scale(1));
-				lView = view; // again, the C macro system i need it so much
+				lView = view; 
 				lUp = up;
 
 				window.anchorToPosView(lPos, lView, lUp);
@@ -91,7 +89,7 @@ public class MoveGrab extends PointerGrab {
 		} else {
 			this.init();
 			lPos = pos.add(view.scale(1));
-			lView = view; // where are C macro system when its really useful
+			lView = view;
 			lUp = up;
 
 			window.anchorToPosView(lPos, lView, lUp);

--- a/src/main/java/dev/evvie/waylandcraft/grabs/MoveGrab.java
+++ b/src/main/java/dev/evvie/waylandcraft/grabs/MoveGrab.java
@@ -2,40 +2,100 @@ package dev.evvie.waylandcraft.grabs;
 
 import dev.evvie.waylandcraft.CursorShape;
 import dev.evvie.waylandcraft.WindowDisplay;
-import dev.evvie.waylandcraft.WindowDisplay.DisplayHitResult;
 import dev.evvie.waylandcraft.grabs.PointerGrabMap.ImplicitGrab;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 
 public class MoveGrab extends PointerGrab {
-	
+
 	private final WindowDisplay window;
 	private final Vec3 initialSurfaceLocal;
+	private Vec3 lPos = Vec3.ZERO;
+	private Vec3 lView = Vec3.ZERO;
+	private Vec3 lUp = Vec3.ZERO;
+	private float rotationAngle = 0.0f;
+	private boolean[] lastRotateState = {false, false}; 
 	
 	public MoveGrab(ImplicitGrab implicit) {
 		super(implicit.button());
 		this.window = implicit.window();
 		this.initialSurfaceLocal = implicit.startSurfaceLocal();
 	}
-	
+
 	@Override
 	public void init() throws GrabDroppedException {
+		rotationAngle = 0.0f;
+		lastRotateState[0] = false;
+		lastRotateState[1] = false;
 	}
-	
+
 	@Override
 	public void release(boolean force) throws GrabDroppedException {
+		window.anchorToPosView(lPos, lView, lUp);
 	}
-	
+
 	@Override
 	public void moveWorld(Vec3 pos, Vec3 view, Vec3 up) throws GrabDroppedException {
 		if(!window.isValid()) this.drop();
-		
 		wlc.cursorShape = CursorShape.ALL_RESIZE;
-		
-		DisplayHitResult hitResult = window.intersect(pos, view);
-		if(hitResult == null) return;
-		
-		Vec3 diff = hitResult.surfaceLocalOrigin.subtract(initialSurfaceLocal);
-		window.pivot = window.pivot.add(window.localX().scale(diff.x).add(window.localY().scale(diff.y)));
+
+		// i cant believe i went out of my way to lower the amount of variables here for this basic stuff
+		if (Minecraft.getInstance().options.keyShift.isDown()) {
+			if (wlc.keyRotateWindowLeft.isDown() && !lastRotateState[0]) {
+				rotationAngle -= 45.0f;
+			}
+			if (wlc.keyRotateWindowRight.isDown() && !lastRotateState[1]) {
+				rotationAngle += 45.0f;
+			}
+		} 
+		lastRotateState[0] = wlc.keyRotateWindowLeft.isDown();
+		lastRotateState[1] = wlc.keyRotateWindowRight.isDown();
+		Vec3 to = pos.add(view.scale(Minecraft.getInstance().player.blockInteractionRange()*2)); // i see no problem with multiplying it by 2
+		BlockHitResult blockHit = Minecraft.getInstance().level.clip(
+			new ClipContext(
+				pos,
+				to, 
+				ClipContext.Block.COLLIDER, 
+				ClipContext.Fluid.NONE, 
+				Minecraft.getInstance().player
+			)
+		);
+		if (Minecraft.getInstance().options.keyShift.isDown()) { // this seemed like a better way to do it till i uhm... did it..
+			if(blockHit.getType() == BlockHitResult.Type.BLOCK) {
+				Vec3 faceDir = new Vec3(blockHit.getDirection().getStepX(), blockHit.getDirection().getStepY(), blockHit.getDirection().getStepZ());
+				lPos = blockHit.getBlockPos().getCenter().add(faceDir.scale(2.55));
+				lView = faceDir.reverse(); // if only all code was like this
+
+				if (Math.abs(faceDir.y) > 0.5) { // is the window at the bottom or top of a block
+					lUp = new Vec3(Math.sin(Math.toRadians(rotationAngle)), 0, Math.cos(Math.toRadians(rotationAngle)));
+				} else {
+					lUp = new Vec3(0, 1, 0); // nu uh you dont get to rotate
+					rotationAngle = 0.0f;
+				}
+
+				window.anchorToPosView(lPos, lView, lUp);
+				return;
+			} else {
+				this.init();
+				lPos = pos.add(view.scale(1));
+				lView = view; // again, the C macro system i need it so much
+				lUp = up;
+
+				window.anchorToPosView(lPos, lView, lUp);
+			}
+		} else {
+			this.init();
+			lPos = pos.add(view.scale(1));
+			lView = view; // where are C macro system when its really useful
+			lUp = up;
+
+			window.anchorToPosView(lPos, lView, lUp);
+		}
 	}
-	
+
 }


### PR DESCRIPTION
this PR makes it so that windows can snap to blocks when moving them (NOT WHEN PLACING THEM) by moving them whilst pressing shift, it also introduces two keybinds to rotate the window when it is snapped to the bottom or top of a block

def not my proudest code but i dont feel like refactoring

ship of thesuesed from [AceiusRedshift](https://github.com/AceiusRedshift)'s code in posted in #29 