### PR TITLE
Fix render node query when missing EGL extension

### DIFF
--- a/native/src/egl.rs
+++ b/native/src/egl.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use smithay::backend::allocator::{
-    Buffer, Format, Fourcc, Modifier, dmabuf::Dmabuf,
+use smithay::backend::{
+    allocator::{Buffer, Format, Fourcc, Modifier, dmabuf::Dmabuf},
+    drm::{DrmNode, NodeType},
 };
 use std::ffi::{CStr, CString};
 use std::os::fd::AsRawFd;
@@ -50,6 +51,7 @@ pub const EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT: EGLAttrib = 0x3449;
 pub const EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT: EGLAttrib = 0x344A;
 
 pub const EGL_DRM_RENDER_NODE_FILE_EXT: EGLint = 0x3377;
+pub const EGL_DRM_DEVICE_FILE_EXT: EGLint = 0x3233;
 
 type ProcAddrFn = extern "C" fn(*const libc::c_char) -> extern "C" fn();
 
@@ -122,7 +124,7 @@ impl EGLHelper {
         }
     }
 
-    pub fn get_render_node(&self) -> &'static str {
+    pub fn get_render_node(&self) -> Result<DrmNode, ()> {
         let mut dev_ret: EGLAttrib = 0;
 
         (self.eglQueryDisplayAttribEXT)(
@@ -130,13 +132,42 @@ impl EGLHelper {
             EGL_DEVICE_EXT,
             &mut dev_ret,
         );
-
         let dev: EGLDeviceEXT = (dev_ret as usize) as EGLDeviceEXT;
 
-        let name_ptr =
+        // Try to query the actual render node (e.g. /dev/dri/renderDN)
+        let path_ptr =
             (self.eglQueryDeviceStringEXT)(dev, EGL_DRM_RENDER_NODE_FILE_EXT);
 
-        unsafe { CStr::from_ptr(name_ptr).to_str().unwrap() }
+        if !path_ptr.is_null() {
+            let path = unsafe { CStr::from_ptr(path_ptr).to_str().unwrap() };
+            return DrmNode::from_path(path).map_err(|_| ());
+        }
+
+        eprintln!("Querying EGL_DRM_RENDER_NODE_FILE_EXT returned null!");
+
+        // Fall back by getting the EGL DRM device
+        let drm_path_ptr =
+            (self.eglQueryDeviceStringEXT)(dev, EGL_DRM_DEVICE_FILE_EXT);
+
+        if drm_path_ptr.is_null() {
+            eprintln!("Querying EGL_DRM_DEVICE_FILE_EXT returned null!");
+            return Err(());
+        }
+
+        let drm_path =
+            unsafe { CStr::from_ptr(drm_path_ptr).to_str().unwrap() };
+
+        let drm_device = DrmNode::from_path(drm_path).map_err(|_| ())?;
+
+        // Try to get a new render node
+        if let Some(render_node) = drm_device.node_with_type(NodeType::Render) {
+            return render_node.map_err(|_| ());
+        }
+
+        eprintln!("Failed to get render node from drm device!");
+
+        // If all else fails, just return the drm master node
+        Ok(drm_device)
     }
 
     pub fn dmabuf_to_image(&self, dmabuf: &Dmabuf) -> EGLImage {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -5,7 +5,7 @@ use crate::output::WLCOutput;
 use crate::seat::WLCSeatState;
 use crate::xdg_spec::XDGSpecHelper;
 use smithay::{
-    backend::{allocator::dmabuf::Dmabuf, drm::DrmNode},
+    backend::allocator::dmabuf::Dmabuf,
     delegate_compositor, delegate_dmabuf, delegate_shm,
     delegate_single_pixel_buffer, delegate_viewporter, delegate_xdg_shell,
     reexports::{
@@ -133,12 +133,12 @@ fn init_dmabuf(
     state: &mut DmabufState,
     egl: &EGLHelper,
 ) -> DmabufGlobal {
-    let render_node_path = egl.get_render_node();
-    let render_node = DrmNode::from_path(render_node_path).unwrap().dev_id();
-
+    let render_node =
+        egl.get_render_node().expect("Failed to get render node!");
+    let render_node_id = render_node.dev_id();
     let formats = egl.query_dmabuf_formats();
 
-    let feedback = DmabufFeedbackBuilder::new(render_node, formats)
+    let feedback = DmabufFeedbackBuilder::new(render_node_id, formats)
         .build()
         .unwrap();
 


### PR DESCRIPTION
Now when the EXT_device_drm_render_node extension is missing, not only does it use a fallback now, it also doesn't segfault due to a missing null pointer check.