### PR TITLE
Add translations for keybinds/keybinds category

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -111,9 +111,9 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		
 		instance = this;
 		
-		keyOpenScreen = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.windowManager", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_B, KEYBIND_CATEGORY));
-		keyOpenAppLauncher = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.appLauncher", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_V, KEYBIND_CATEGORY));
-		keyCaptureKeyboard = KeyMappingHelper.registerKeyMapping(new KeyMapping("key.captureKeyboard", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_G, KEYBIND_CATEGORY));
+		keyOpenScreen = KeyMappingHelper.registerKeyMapping(new KeyMapping("waylandcraft.key.windowManager", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_B, KEYBIND_CATEGORY));
+		keyOpenAppLauncher = KeyMappingHelper.registerKeyMapping(new KeyMapping("waylandcraft.key.appLauncher", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_V, KEYBIND_CATEGORY));
+		keyCaptureKeyboard = KeyMappingHelper.registerKeyMapping(new KeyMapping("waylandcraft.key.captureKeyboard", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_G, KEYBIND_CATEGORY));
 		
 		LevelRenderEvents.COLLECT_SUBMITS.register(this::renderWorld);
 		LevelRenderEvents.END_EXTRACTION.register(this::updateWorld);
@@ -671,3 +671,4 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 	}
 	
 }
+

--- a/src/main/resources/assets/waylandcraft/lang/en_us.json
+++ b/src/main/resources/assets/waylandcraft/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+	"key.category.waylandcraft.keys": "Waylandcraft",
+	"key.appLauncher": "App Launcher",
+	"key.windowManager": "Window Manager",
+	"key.captureKeyboard": "Capture Keyboard"
+}

--- a/src/main/resources/assets/waylandcraft/lang/en_us.json
+++ b/src/main/resources/assets/waylandcraft/lang/en_us.json
@@ -1,6 +1,6 @@
 {
 	"key.category.waylandcraft.keys": "Waylandcraft",
-	"key.appLauncher": "App Launcher",
-	"key.windowManager": "Window Manager",
-	"key.captureKeyboard": "Capture Keyboard"
+	"waylandcraft.key.appLauncher": "App Launcher",
+	"waylandcraft.key.windowManager": "Window Manager",
+	"waylandcraft.key.captureKeyboard": "Capture Keyboard"
 }


### PR DESCRIPTION
## Added en_Us translation for keybinds.

turns:
<img width="1059" height="249" alt="image" src="https://github.com/user-attachments/assets/65a95381-c0c5-4aa5-ab77-1bc883fe6d6c" />

into:
<img width="1059" height="249" alt="image" src="https://github.com/user-attachments/assets/141e7004-e1a6-47bc-b238-0db3365c5f58" />

Also, updated keys names to be mod specific, emitting conflicts
