### PR TITLE
Fix game window desktop bleed-through

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -126,7 +126,7 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 	}
 	
 	/* Update bridge and clients. May be called at any state of the game, even outside of a level
-	 * Called before game render in Minecraft::runTick
+	 * Called after game render in Minecraft::runTick
 	 */
 	public void update() {
 		if(bridge == null) {

--- a/src/main/java/dev/evvie/waylandcraft/mixin/MinecraftMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/MinecraftMixin.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.render.WindowTranslucencyHotfix;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -17,8 +18,13 @@ import net.minecraft.world.phys.Vec3;
 public class MinecraftMixin {
 	
 	@Inject(method = "runTick", at = @At(value = "INVOKE_STRING", target = "Lcom/mojang/blaze3d/platform/Window;setErrorSection(Ljava/lang/String;)V", args = "ldc=Post render"))
-	public void runTick(boolean doTick, CallbackInfo info) {
+	public void updateRunTick(boolean doTick, CallbackInfo info) {
 		WaylandCraft.instance.update();
+	}
+	
+	@Inject(method = "renderFrame", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=present"))
+	public void hotfixRenderFrame(boolean advanceGameTime, CallbackInfo info) {
+		WindowTranslucencyHotfix.render();
 	}
 	
 	@Inject(method = "pick", at = @At("TAIL"))

--- a/src/main/java/dev/evvie/waylandcraft/render/WindowTranslucencyHotfix.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/WindowTranslucencyHotfix.java
@@ -1,0 +1,44 @@
+package dev.evvie.waylandcraft.render;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+
+import dev.evvie.waylandcraft.WaylandCraft;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.resources.Identifier;
+
+public class WindowTranslucencyHotfix {
+	
+	private static final RenderPipeline TRANSLUCENCY_HOTFIX_PIPELINE = RenderPipelines.register(
+			RenderPipeline.builder()
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/translucency_hotfix"))
+			.withVertexShader("core/screenquad")
+			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/singlecolor"))
+			.withColorTargetState(new ColorTargetState(Optional.empty(), ColorTargetState.WRITE_ALPHA))
+			.withVertexFormat(DefaultVertexFormat.EMPTY, VertexFormat.Mode.TRIANGLES)
+			.withShaderDefine("RED", 1.0f)
+			.withShaderDefine("GREEN", 1.0f)
+			.withShaderDefine("BLUE", 1.0f)
+			.withShaderDefine("ALPHA", 1.0f)
+			.build()
+	);
+	
+	public static void render() {
+		if(Minecraft.getInstance().level == null) return;
+		
+		OptionalInt clearColor = OptionalInt.empty();
+		try(RenderPass pass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "translucency_hotfix", Minecraft.getInstance().getMainRenderTarget().getColorTextureView(), clearColor)) {
+			pass.setPipeline(TRANSLUCENCY_HOTFIX_PIPELINE);
+			pass.draw(0, 3);
+		}
+	}
+	
+}

--- a/src/main/resources/assets/waylandcraft/shaders/core/singlecolor.fsh
+++ b/src/main/resources/assets/waylandcraft/shaders/core/singlecolor.fsh
@@ -1,0 +1,7 @@
+#version 330
+
+out vec4 Color;
+
+void main() {
+	Color = vec4(RED, GREEN, BLUE, ALPHA);
+}


### PR DESCRIPTION
In certain circumstances the game rendering translucency actually propagates all the way through into the final pixel buffer submitted to the root session, causing the game window to be rendered translucently, which made many users see their desktop through it. This fix renders an opaque screenquad to the alpha channel of the main render target after the game rendering is done to force all pixel values to be opaque.