### PR TITLE
Downgrade wl_seat global to 8, change key repeat delay

### DIFF
--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -179,7 +179,7 @@ impl WLCSeatState {
     }
 
     pub fn create_globals(&self, disp: &DisplayHandle) {
-        disp.create_global::<WLCState, WlSeat, ()>(10, ());
+        disp.create_global::<WLCState, WlSeat, ()>(8, ());
         disp.create_global::<WLCState, ZwpRelativePointerManagerV1, ()>(1, ());
         disp.create_global::<WLCState, ZwpPointerConstraintsV1, ()>(1, ());
         disp.create_global::<WLCState, WpCursorShapeManagerV1, ()>(2, ());
@@ -649,7 +649,7 @@ impl Dispatch<WlSeat, ()> for WLCState {
                     keymap.size() as u32,
                 );
 
-                keyboard.repeat_info(25, 200);
+                keyboard.repeat_info(25, 600);
             }
             _ => {
                 seat_resource.post_error(


### PR DESCRIPTION
Advertising version 10 of the wl_seat global leads some applications, notably kitty, to assume that the compositor takes care of key repeat even though that is an incorrect interpretation of the protocol. A correct fix might be implementing key repeat in the compositor, but this hotpatch is enough to fix this issue. Additionally the repeat delay has been increased to 600ms to fit in with other wayland compositors.