### PR TITLE
[Discussion]  Proposed Entity Renderer for Shader Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+  maven { url "https://api.modrinth.com/maven" }
+
 }
 
 dependencies {
@@ -26,6 +28,7 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	
+  compileOnly "maven.modrinth:iris:${iris_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,5 @@ archives_base_name=waylandcraft
 
 # Dependencies
 fabric_version=0.147.0+26.1.2
+
+iris_version=1.10.9+26.1-fabric

--- a/src/main/java/dev/evvie/waylandcraft/render/RenderUtils.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/RenderUtils.java
@@ -1,150 +1,82 @@
 package dev.evvie.waylandcraft.render;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
-
-import com.mojang.blaze3d.pipeline.BlendFunction;
-import com.mojang.blaze3d.pipeline.ColorTargetState;
-import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.textures.AddressMode;
-import com.mojang.blaze3d.textures.FilterMode;
-import com.mojang.blaze3d.textures.GpuSampler;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.PoseStack.Pose;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.blaze3d.vertex.VertexFormat;
-
-import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.mixin.IGuiGraphicsExtractor;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.SubmitNodeCollector.CustomGeometryRenderer;
-import net.minecraft.client.renderer.rendertype.RenderSetup;
 import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Util;
 import net.minecraft.world.phys.Vec3;
 
 public class RenderUtils {
-	
-	private static final RenderPipeline.Snippet WINDOW_PIPELINE_SNIPPET = RenderPipeline.builder(RenderPipelines.MATRICES_PROJECTION_SNIPPET)
-			.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/rendertype_window"))
-			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/rendertype_window"))
-			.withSampler("Sampler0")
-			.withDepthStencilState(DepthStencilState.DEFAULT)
-			.withVertexFormat(DefaultVertexFormat.POSITION_TEX, VertexFormat.Mode.QUADS)
-			.buildSnippet();
-	
-	private static final RenderPipeline WINDOW_CUTOUT_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_cutout"))
-			.withShaderDefine("ALPHA_CUTOUT")
-			.build();
-	
-	private static final RenderPipeline WINDOW_TRANSLUCENT_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_translucent"))
-			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
-			.build();
-	
-	private static final RenderPipeline WINDOW_CUTOUT_BACKGROUND_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_cutout_background"))
-			.withShaderDefine("ALPHA_CUTOUT")
-			.withShaderDefine("NO_COLOR")
-			.build();
-	
-	private static final RenderPipeline WINDOW_TRANSLUCENT_BACKGROUND_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_translucent_background"))
-			.withShaderDefine("NO_COLOR")
-			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
-			.build();
-	
-	public static final Supplier<GpuSampler> WINDOW_SAMPLER = () -> RenderSystem.getSamplerCache().getSampler(AddressMode.CLAMP_TO_EDGE, AddressMode.CLAMP_TO_EDGE, FilterMode.LINEAR, FilterMode.NEAREST, false);
-	
-	public static final Function<Identifier, RenderType> WINDOW_CUTOUT = Util.memoize(
-		(identifier) -> {
-			RenderSetup setup = RenderSetup.builder(WINDOW_CUTOUT_PIPELINE)
-					.withTexture("Sampler0", identifier, WINDOW_SAMPLER)
-					.createRenderSetup();
-			return RenderType.create("window_cutout", setup);
-		}
-	);
-	
-	public static final Function<Identifier, RenderType> WINDOW_TRANSLUCENT = Util.memoize(
-		(identifier) -> {
-			RenderSetup setup = RenderSetup.builder(WINDOW_TRANSLUCENT_PIPELINE)
-					.withTexture("Sampler0", identifier, WINDOW_SAMPLER)
-					.createRenderSetup();
-			return RenderType.create("window_translucent", setup);
-		}
-	);
-	
-	public static final Function<Identifier, RenderType> WINDOW_BACKGROUND_CUTOUT = Util.memoize(
-		(identifier) -> {
-			RenderSetup setup = RenderSetup.builder(WINDOW_CUTOUT_BACKGROUND_PIPELINE)
-					.withTexture("Sampler0", identifier, WINDOW_SAMPLER)
-					.createRenderSetup();
-			return RenderType.create("window_cutout_background", setup);
-		}
-	);
-	
-	public static final Function<Identifier, RenderType> WINDOW_BACKGROUND_TRANSLUCENT = Util.memoize(
-		(identifier) -> {
-			RenderSetup setup = RenderSetup.builder(WINDOW_TRANSLUCENT_BACKGROUND_PIPELINE)
-					.withTexture("Sampler0", identifier, WINDOW_SAMPLER)
-					.createRenderSetup();
-			return RenderType.create("window_translucent_background", setup);
-		}
-	);
-	
-	public static final RenderPipeline WINDOW_BLIT = RenderPipeline.builder(RenderPipelines.MATRICES_PROJECTION_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_blit"))
-			.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/window_blit"))
-			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/window_blit"))
-			.withSampler("Sampler0")
-			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
-			.withVertexFormat(DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS)
-			.build();
-	
+
+  public static final Function<Identifier, RenderType> WINDOW_CUTOUT =
+    Util.memoize(id -> RenderTypes.entityCutout(id));
+
+  public static final Function<Identifier, RenderType> WINDOW_TRANSLUCENT =
+      Util.memoize(id -> RenderTypes.entityTranslucent(id));
+
+	public static final RenderPipeline WINDOW_BLIT = RenderPipelines.GUI_TEXTURED;
+
 	public static void renderFramebuffer(WindowFramebuffer framebuffer, PoseStack poseStack, SubmitNodeCollector collector, boolean cutout, Vec3 tl, Vec3 bl, Vec3 br, Vec3 tr) {
 		if(!framebuffer.isValid()) return;
-		
-		Function<Identifier, RenderType> renderType;
-		
-		// Front quad
-		renderType = cutout ? WINDOW_CUTOUT : WINDOW_TRANSLUCENT;
-		collector.submitCustomGeometry(poseStack, renderType.apply(framebuffer.getTextureLocation()), new FramebufferRenderInstance(tl, bl, br, tr, false));
-		
-		// Back quad
-		renderType = cutout ? WINDOW_BACKGROUND_CUTOUT : WINDOW_BACKGROUND_TRANSLUCENT;
-		collector.submitCustomGeometry(poseStack, renderType.apply(framebuffer.getTextureLocation()), new FramebufferRenderInstance(tl, bl, br, tr, true));
+     collector.submitCustomGeometry(poseStack,
+         cutout ? WINDOW_CUTOUT.apply(framebuffer.getTextureLocation())
+                : WINDOW_TRANSLUCENT.apply(framebuffer.getTextureLocation()),
+        new FramebufferRenderInstance(tl, bl, br, tr));
 	}
-	
-	public static final record FramebufferRenderInstance(Vec3 tl, Vec3 bl, Vec3 br, Vec3 tr, boolean reverse) implements CustomGeometryRenderer {
-		
+
+	public static final record FramebufferRenderInstance(Vec3 tl, Vec3 bl, Vec3 br, Vec3 tr) implements CustomGeometryRenderer {
+
 		@Override
 		public void render(Pose pose, VertexConsumer buffer) {
-			if(!reverse) {
-				buffer.addVertex(pose, tl.toVector3f()).setUv(0.0f, 0.0f);
-				buffer.addVertex(pose, bl.toVector3f()).setUv(0.0f, 1.0f);
-				buffer.addVertex(pose, br.toVector3f()).setUv(1.0f, 1.0f);
-				buffer.addVertex(pose, tr.toVector3f()).setUv(1.0f, 0.0f);
-			}
-			else {
-				buffer.addVertex(pose, tr.toVector3f()).setUv(1.0f, 0.0f);
-				buffer.addVertex(pose, br.toVector3f()).setUv(1.0f, 1.0f);
-				buffer.addVertex(pose, bl.toVector3f()).setUv(0.0f, 1.0f);
-				buffer.addVertex(pose, tl.toVector3f()).setUv(0.0f, 0.0f);
-			}
+      // Front face
+      buffer.addVertex(pose, tl.toVector3f())
+          .setColor(1.0f, 1.0f, 1.0f, 1.0f)
+          .setUv(0.0f, 0.0f)
+          .setOverlay(OverlayTexture.NO_OVERLAY)
+          .setLight(0xF000F0)
+          .setNormal(pose, 0.0f, 0.0f, 1.0f);
+      buffer.addVertex(pose, bl.toVector3f())
+          .setColor(1.0f, 1.0f, 1.0f, 1.0f)
+          .setUv(0.0f, 1.0f)
+          .setOverlay(OverlayTexture.NO_OVERLAY)
+          .setLight(0xF000F0)
+          .setNormal(pose, 0.0f, 0.0f, 1.0f);
+      buffer.addVertex(pose, br.toVector3f())
+          .setColor(1.0f, 1.0f, 1.0f, 1.0f)
+          .setUv(1.0f, 1.0f)
+          .setOverlay(OverlayTexture.NO_OVERLAY)
+          .setLight(0xF000F0)
+          .setNormal(pose, 0.0f, 0.0f, 1.0f);
+      buffer.addVertex(pose, tr.toVector3f())
+          .setColor(1.0f, 1.0f, 1.0f, 1.0f)
+          .setUv(1.0f, 0.0f)
+          .setOverlay(OverlayTexture.NO_OVERLAY)
+          .setLight(0xF000F0)
+          .setNormal(pose, 0.0f, 0.0f, 1.0f);
+      // Back face — same positions reversed, normal flipped, color black
+      buffer.addVertex(pose, tr.toVector3f())
+          .setColor(0.0f, 0.0f, 0.0f, 1.0f)
+          .setUv(1.0f, 0.0f)
+          .setOverlay(OverlayTexture.NO_OVERLAY)
+          .setLight(0xF000F0)
+          .setNormal(pose, 0.0f, 0.0f, -1.0f);
 		}
-		
 	}
-	
+
 	public static void renderFramebuffer2D(GuiGraphicsExtractor context, WindowFramebuffer framebuffer, int x, int y, int w, int h) {
 		if(!framebuffer.isValid()) return;
 		((IGuiGraphicsExtractor) context).invokeInnerBlit(WINDOW_BLIT, framebuffer.getTextureLocation(), x, x + w, y, y + h, 0.0f, 1.0f, 0.0f, 1.0f, -1);
 	}
-	
+
 }

--- a/src/main/java/dev/evvie/waylandcraft/render/compat/IrisCompat.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/compat/IrisCompat.java
@@ -1,0 +1,20 @@
+package dev.evvie.waylandcraft.render.compat;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.irisshaders.iris.api.v0.IrisApi;
+
+/**
+ * IrisCompat
+ *
+ * This is an example Class to detect if Iris is loaded and a shader pack is in use,
+ * this could be used in RenderUtils to separate the custom rendering pipeline from 
+ * the Entity rendering pipeline so shaders can be compatible until a better alternative 
+ * is made.
+ */
+public class IrisCompat {
+  private static final boolean IRIS_LOADED = FabricLoader.getInstance().isModLoaded("iris");
+
+  public static boolean isActive() {
+    return IRIS_LOADED && IrisApi.getInstance().isShaderPackInUse();
+  }
+}


### PR DESCRIPTION
### Contribution Policy Disclosure:
I used an LLM to find the best way to have the windows remain compatible with shaders without rewriting the entire rendering pipeline, ultimately the best way seemed to be using the game existing Entity rendering without using the current custom one by modifying RenderUtils.

# Discussion
I'm not expecting this PR to be merged into the main project but I'm curious as to why the current implementation uses a custom rendering pipeline rather than one that mods like Iris are compatible with. I'm assuming this is because in order to keep the windows true colors and other effects it is necessary to separate them. But I figured I'd ask and write an example alternative just to get some insight. I have tested the fork I've made and am pretty sure it works but I would be open to criticism.

_Fork Screenshot_:
<img width="1908" height="989" alt="2026-05-25_14 53 59" src="https://github.com/user-attachments/assets/e981a2ce-ff1b-40e4-9c8b-1402bc363772" />

**TLDR**: I'd like to ask, why is the current rendering done custom rather than using entity rendering?