### PR TITLE
Fix missing pointer frame event on relative motion

### DIFF
--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -286,7 +286,7 @@ impl WLCSeatState {
 
     // Emit relative movement on the surface with active pointer focus
     pub fn pointer_relative_motion(&self, dx: f64, dy: f64) {
-        self.for_all_pointers(|_pointer, data| {
+        self.for_all_pointers(|pointer, data| {
             if data.focus.is_none() {
                 return;
             }
@@ -301,6 +301,7 @@ impl WLCSeatState {
                     dy,                         // dy_unaccel
                 );
             }
+            self.pointer_frame(pointer);
         });
     }
 


### PR DESCRIPTION
I can't believe how I didn't notice this. The relative pointer event did not send a pointer frame event, and for that reason clients queued up relative motion events until a frame was dispatched. This broke relative pointer events for basically all clients using it with a wl_pointer version above 5.