### PR TITLE
Item manager: Only remove item when toplevel gone

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItemManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItemManager.java
@@ -77,7 +77,7 @@ public class WindowItemManager {
 				if(!item.is(WindowItem.WINDOW)) continue;
 				
 				WLCToplevel toplevel = WindowItem.getToplevel(item);
-				if(!isToplevelValid(toplevel)) {
+				if(toplevel == null) {
 					inv.setItem(i, ItemStack.EMPTY);
 				}
 			}


### PR DESCRIPTION
Previously the item manager would take away toplevels when they were unmapped, unfortunately a lot of applications unmap their toplevels for small durations and the item being taken away then becomes annoying. This fixes #103 