### PR TITLE
Implement window block center snapping

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -203,9 +203,12 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 						display.anchorDistance = 2.0;
 					}
 					
+					display.anchorToCamera(camera);
+					
 					boolean modDown = InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), GLFW.GLFW_KEY_LEFT_ALT);
-					if(!(modDown && display.trySnapWorld(camera.position(), new Vec3(camera.forwardVector()), camera.yRot()))) {
-						display.anchorToCamera(camera);
+					boolean ctrlDown = InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), GLFW.GLFW_KEY_LEFT_CONTROL);
+					if(modDown) {
+						display.trySnapWorld(camera.position(), new Vec3(camera.forwardVector()), camera.yRot(), ctrlDown);
 					}
 					
 					WaylandCraft.instance.bridge.focusSurface(toplevel);

--- a/src/main/java/dev/evvie/waylandcraft/WindowDisplay.java
+++ b/src/main/java/dev/evvie/waylandcraft/WindowDisplay.java
@@ -13,6 +13,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderContext;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Direction.Axis;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.BlockHitResult;
@@ -210,9 +211,9 @@ public class WindowDisplay {
 		anchorToPosView(WaylandCraftUtils.getPosition(entity), WaylandCraftUtils.getLookVector(entity), WaylandCraftUtils.getUpVector(entity));
 	}
 	
-	public boolean trySnapWorld(Vec3 pos, Vec3 view, float yRot) {
-		BlockHitResult hitResult = Minecraft.getInstance().level.clip(new ClipContext(pos, pos.add(view.scale(10.0)), ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, Minecraft.getInstance().player));
-		if(hitResult.getType() != HitResult.Type.BLOCK) return false;
+	public void trySnapWorld(Vec3 pos, Vec3 view, float yRot, boolean center) {
+		BlockHitResult hitResult = Minecraft.getInstance().level.clip(new ClipContext(pos, pos.add(view.scale(32.0)), ClipContext.Block.VISUAL, ClipContext.Fluid.NONE, Minecraft.getInstance().player));
+		if(hitResult.getType() != HitResult.Type.BLOCK) return;
 		
 		Direction blockNormal = hitResult.getDirection();
 		Direction viewDirection = Direction.fromYRot(yRot);
@@ -226,9 +227,23 @@ public class WindowDisplay {
 		}
 		
 		this.rotate(blockNormal.getUnitVec3(), downDirection.getUnitVec3());
-		this.pivot = hitResult.getLocation().add(blockNormal.getUnitVec3().scale(0.01));
+		this.pivot = hitResult.getLocation().add(blockNormal.getUnitVec3().scale(0.03));
 		
-		return true;
+		if(center) {
+			double centerX = Math.floor(pivot.x) + 0.5;
+			double centerY = Math.floor(pivot.y) + 0.5;
+			double centerZ = Math.floor(pivot.z) + 0.5;
+			
+			if(blockNormal.getAxis().equals(Axis.X)) {
+				this.pivot = new Vec3(pivot.x, centerY, centerZ);
+			}
+			else if(blockNormal.getAxis().equals(Axis.Y)) {
+				this.pivot = new Vec3(centerX, pivot.y, centerZ);
+			}
+			else if(blockNormal.getAxis().equals(Axis.Z)) {
+				this.pivot = new Vec3(centerX, centerY, pivot.z);
+			}
+		}
 	}
 	
 	public static class DisplayHitResult {

--- a/src/main/java/dev/evvie/waylandcraft/grabs/WindowGrab.java
+++ b/src/main/java/dev/evvie/waylandcraft/grabs/WindowGrab.java
@@ -6,10 +6,6 @@ import com.mojang.blaze3d.platform.InputConstants;
 
 import dev.evvie.waylandcraft.WindowDisplay;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.Direction;
-import net.minecraft.world.level.ClipContext;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
 public class WindowGrab extends PointerGrab {
@@ -42,10 +38,13 @@ public class WindowGrab extends PointerGrab {
 	public void moveWorld(Vec3 pos, Vec3 view, Vec3 up, float yRot, float xRot) throws GrabDroppedException {
 		this.checkValid();
 		
-		boolean modDown = InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), GLFW.GLFW_KEY_LEFT_ALT);
-		if(modDown && window.trySnapWorld(pos, view, yRot)) return;
-		
 		window.anchorToPosView(pos, view, up);
+		
+		boolean modDown = InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), GLFW.GLFW_KEY_LEFT_ALT);
+		boolean ctrlDown = InputConstants.isKeyDown(Minecraft.getInstance().getWindow(), GLFW.GLFW_KEY_LEFT_CONTROL);
+		if(modDown) {
+			window.trySnapWorld(pos, view, yRot, ctrlDown);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Pressing CTRL and ALT at the same time now allows you to center snap windows to blocks