### PR TITLE
feat: add Android DroidSpaces helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Wayland Compositor in Minecraft
 
+[中文说明](README.zh-CN.md)
+
 [Demo video](https://youtu.be/cTkEM7b0IQw)
 
 Now available on [Modrinth](https://modrinth.com/mod/waylandcraft)!

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,185 @@
+# WaylandCraft 中文说明
+
+![waylandcraft banner](/assets/title_scaled.png)
+
+WaylandCraft 是一个运行在 Minecraft 内部的 Wayland 合成器。它可以把 Linux 图形应用作为窗口显示在 Minecraft 世界里。
+
+原项目视频：<https://youtu.be/cTkEM7b0IQw>
+
+Modrinth 页面：<https://modrinth.com/mod/waylandcraft>
+
+## 系统依赖
+
+- Linux
+- Minecraft 26.1.2
+- Fabric Loader
+- xkbcommon 1.11.0
+- xkbcommon tools，例如 `xkbcli`
+- Rust 开发环境
+- Java 25 SDK
+
+推荐：
+
+- Prism Launcher
+- Sodium
+- xwayland-satellite
+
+## 重要使用提示
+
+1. 不要使用 Flatpak 打包的 Minecraft 启动器，否则应用窗口可能无法正常使用。
+2. NVIDIA 用户建议设置环境变量：`__GL_THREADED_OPTIMIZATIONS=0`。
+3. 如果 NVIDIA 上有奇怪的图形瑕疵，可以在视频设置里开启 “Improved Transparency”。
+4. Zink OpenGL 驱动可能导致问题，建议使用原生 OpenGL。
+
+## 默认按键
+
+- `V`：打开应用启动器。
+- `B`：打开窗口管理界面。
+- `G`：普通键盘捕获，用于向窗口输入文字。
+- `ALT+Q`：硬键盘捕获，可把 `ESC` 等按键转发给窗口。再次按 `ALT+Q` 退出。
+
+## 运行 X11 应用
+
+WaylandCraft 目前没有直接集成 Xwayland。需要在游戏内终端启动：
+
+```sh
+xwayland-satellite :2
+```
+
+之后启动 X11 应用时指定 `DISPLAY`：
+
+```sh
+DISPLAY=:2 xterm
+DISPLAY=:2 steam
+```
+
+## 构建与开发运行
+
+```sh
+./build.sh
+```
+
+最终 jar 在 `build/libs`。开发环境可以运行：
+
+```sh
+./gradlew runClient
+```
+
+## Android / DroidSpaces / Termux-X11 辅助脚本
+
+本分支增加了一组辅助脚本，方便在 Android DroidSpaces Ubuntu 容器 + Termux-X11 + Termux PulseAudio 环境里运行。
+
+这些脚本主要解决两类问题：
+
+1. 图形：从 Ubuntu 容器连接 Termux-X11。
+2. 声音：从 Ubuntu 容器通过 TCP 连接 Termux 侧 PulseAudio，并输出到 Android `AAudio_sink`。
+
+### 1. Termux 宿主侧启动音频和 X11
+
+在 Termux 里运行：
+
+```sh
+cd /path/to/waylandcraft
+X11_DISPLAY=:0 ./scripts/android/termux_audio_x11_setup.sh
+```
+
+脚本会尝试：
+
+- 使用用户自己的 `$HOME/.termux-pulse-runtime`，避免 `$PREFIX/tmp` 被 root 拥有导致 PulseAudio 无法启动。
+- 启动或重启 Termux PulseAudio。
+- 加载 `module-aaudio-sink`。
+- 把默认 sink 设置为 `AAudio_sink`。
+- 加载 `module-native-protocol-tcp auth-anonymous=1`，监听 `4713` 端口。
+- 启动或复用 `termux-x11 :0`。
+- 尝试隐藏 Android 软键盘。
+
+成功时应该能看到：
+
+```text
+Default Sink: AAudio_sink
+module-aaudio-sink
+module-native-protocol-tcp auth-anonymous=1
+0.0.0.0:4713 LISTEN
+```
+
+如果 Android 软键盘仍然挡住窗口，请在 Termux-X11 的菜单里手动关闭 `Show keyboard` / `Soft keyboard`，并开启 `Fullscreen` / `Immersive mode` / `Hide system bars`。
+
+### 2. Ubuntu 容器侧一键启动 WaylandCraft
+
+在 DroidSpaces Ubuntu 容器里运行：
+
+```sh
+cd /home/user/waylandcraft
+./scripts/android/run_waylandcraft.sh
+```
+
+默认环境：
+
+```sh
+DISPLAY=:0
+PULSE_SERVER=tcp:127.0.0.1:4713
+ALSOFT_DRIVERS=pulse
+```
+
+这会让 Minecraft/OpenAL 走 Termux PulseAudio，而不是容器里的 dummy PulseAudio。
+
+如果要全屏启动：
+
+```sh
+WLC_FULLSCREEN=1 ./scripts/android/run_waylandcraft.sh
+```
+
+如果要强制指定横屏尺寸：
+
+```sh
+WLC_FULLSCREEN=1 WLC_WIDTH=2272 WLC_HEIGHT=1080 ./scripts/android/run_waylandcraft.sh
+```
+
+### 3. 单独隐藏软键盘
+
+在 Termux 里运行：
+
+```sh
+./scripts/android/termux_hide_keyboard.sh
+```
+
+脚本会尝试调用 `termux-keyboard-hide`、Android `input keyevent BACK/ESC`，并在 root 可用时尝试切换到非软键盘输入法。
+
+### 4. 强制调整 X11 窗口大小/位置
+
+如果容器里没有 `xdotool` 或 `wmctrl`，可以使用 libX11 辅助脚本：
+
+```sh
+wid=$(DISPLAY=:0 xwininfo -root -tree | awk '/Minecraft\*/ {print $1; exit}')
+python3 tools/x_move_resize.py :0 "$wid" 0 0 1080 2277
+```
+
+参数含义：
+
+```text
+DISPLAY 窗口ID X Y 宽 高
+```
+
+## Android 音频排错
+
+容器里本地 PulseAudio 可能只有 `auto_null`，这只是 dummy 输出，不会有声音。应使用：
+
+```sh
+export PULSE_SERVER=tcp:127.0.0.1:4713
+export ALSOFT_DRIVERS=pulse
+```
+
+测试：
+
+```sh
+PULSE_SERVER=tcp:127.0.0.1:4713 pactl info
+PULSE_SERVER=tcp:127.0.0.1:4713 paplay /usr/share/sounds/freedesktop/stereo/audio-volume-change.oga
+```
+
+如果 `pactl info` 能看到 `Default Sink: AAudio_sink`，并且 `paplay` 有声音，说明容器到 Android 的声音链路已经打通。
+
+## 免责声明
+
+WaylandCraft 仍有许多限制和 bug。请自行承担使用风险。
+
+贡献请遵守 GPLv3 许可证和原项目的贡献政策。

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -133,16 +133,26 @@ fn init_dmabuf(
     state: &mut DmabufState,
     egl: &EGLHelper,
 ) -> DmabufGlobal {
-    let render_node =
-        egl.get_render_node().expect("Failed to get render node!");
-    let render_node_id = render_node.dev_id();
     let formats = egl.query_dmabuf_formats();
 
-    let feedback = DmabufFeedbackBuilder::new(render_node_id, formats)
-        .build()
-        .unwrap();
+    match egl.get_render_node() {
+        Ok(render_node) => {
+            let render_node_id = render_node.dev_id();
+            let feedback = DmabufFeedbackBuilder::new(render_node_id, formats)
+                .build()
+                .unwrap();
 
-    state.create_global_with_default_feedback::<WLCState>(disp, &feedback)
+            state.create_global_with_default_feedback::<WLCState>(
+                disp, &feedback,
+            )
+        }
+        Err(()) => {
+            eprintln!(
+                "Failed to get render node; falling back to linux-dmabuf v3 without default feedback"
+            );
+            state.create_global::<WLCState>(disp, formats)
+        }
+    }
 }
 
 impl CompositorHandler for WLCState {

--- a/scripts/android/run_waylandcraft.sh
+++ b/scripts/android/run_waylandcraft.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WaylandCraft one-key launcher for DroidSpaces Ubuntu container + Termux-X11 + Termux PulseAudio.
+# Run inside the Ubuntu container:
+#   cd /home/user/waylandcraft
+#   ./scripts/android/run_waylandcraft.sh
+#
+# Before running this, start Termux host audio with:
+#   X11_DISPLAY=:0 ./scripts/android/termux_audio_x11_setup.sh
+#
+# Optional env:
+#   DISPLAY=:0
+#   WLC_PULSE_SERVER=tcp:127.0.0.1:4713
+#   WLC_FULLSCREEN=0|1
+#   WLC_WIDTH=2272 WLC_HEIGHT=1080    # only used when WLC_FULLSCREEN=1 and set explicitly
+#   WLC_KILL_EXISTING=1
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+DISPLAY="${DISPLAY:-:0}"
+PULSE_SERVER="${WLC_PULSE_SERVER:-tcp:127.0.0.1:4713}"
+KILL_EXISTING="${WLC_KILL_EXISTING:-1}"
+FULLSCREEN="${WLC_FULLSCREEN:-0}"
+
+log() { printf '%s\n' "$*"; }
+
+get_root_size() {
+  DISPLAY="$DISPLAY" xwininfo -root 2>/dev/null | awk '
+    /Width:/ {w=$2}
+    /Height:/ {h=$2}
+    END { if (w && h) print w " " h; else exit 1 }
+  '
+}
+
+set_option() {
+  local key="$1" value="$2"
+  python3 - "$key" "$value" <<'PY'
+from pathlib import Path
+import sys
+key, value = sys.argv[1], sys.argv[2]
+p = Path('run/options.txt')
+p.parent.mkdir(exist_ok=True)
+text = p.read_text() if p.exists() else ''
+lines = text.splitlines()
+out = []
+seen = False
+for line in lines:
+    if line.startswith(key + ':'):
+        out.append(f'{key}:{value}')
+        seen = True
+    else:
+        out.append(line)
+if not seen:
+    out.append(f'{key}:{value}')
+p.write_text('\n'.join(out) + '\n')
+PY
+}
+
+log "🖥️ DISPLAY=$DISPLAY"
+log "🔊 PULSE_SERVER=$PULSE_SERVER"
+log "🔊 ALSOFT_DRIVERS=pulse"
+
+# Quick audio server check. Do not fail hard: Minecraft may still start, but this warns early.
+if command -v pactl >/dev/null 2>&1; then
+  if PULSE_SERVER="$PULSE_SERVER" timeout 5 pactl info >/tmp/wlc-pactl-info.txt 2>&1; then
+    log "✅ PulseAudio reachable: $(grep -m1 '^Server Name:' /tmp/wlc-pactl-info.txt | cut -d: -f2- | xargs)"
+    log "✅ Default sink: $(grep -m1 '^Default Sink:' /tmp/wlc-pactl-info.txt | cut -d: -f2- | xargs)"
+  else
+    log "⚠️ PulseAudio 暂时不可达：$PULSE_SERVER"
+    sed -n '1,10p' /tmp/wlc-pactl-info.txt || true
+    log "   请先在 Termux 运行: X11_DISPLAY=:0 ./termux_audio_x11_setup.sh"
+  fi
+fi
+
+if [ "$FULLSCREEN" = "1" ]; then
+  if [ -n "${WLC_WIDTH:-}" ] && [ -n "${WLC_HEIGHT:-}" ]; then
+    WIDTH="$WLC_WIDTH"
+    HEIGHT="$WLC_HEIGHT"
+  else
+    read -r WIDTH HEIGHT < <(get_root_size)
+  fi
+  log "🖼️ 设置 Minecraft 全屏: ${WIDTH}x${HEIGHT}"
+  set_option fullscreen true
+  set_option exclusiveFullscreen false
+  set_option overrideWidth "$WIDTH"
+  set_option overrideHeight "$HEIGHT"
+else
+  log "🪟 使用 Minecraft 默认窗口大小"
+  set_option fullscreen false
+  set_option exclusiveFullscreen false
+  set_option overrideWidth 0
+  set_option overrideHeight 0
+fi
+
+if [ "$KILL_EXISTING" = "1" ]; then
+  log "🧹 stopping existing runClient/Minecraft if any..."
+  pkill -f 'net.fabricmc.devlaunchinjector.Main|gradle-wrapper.jar runClient' 2>/dev/null || true
+  sleep 2
+fi
+
+source ~/.cargo/env 2>/dev/null || true
+export DISPLAY
+export LIBRARY_PATH=/home/user/.local/lib
+export LD_LIBRARY_PATH="$ROOT_DIR/native/target/debug:/home/user/.local/lib:${LD_LIBRARY_PATH:-}"
+export PULSE_SERVER
+export ALSOFT_DRIVERS=pulse
+
+log "🚀 starting WaylandCraft..."
+log "   cwd=$ROOT_DIR"
+exec ./gradlew runClient --console=plain

--- a/scripts/android/run_waylandcraft_fullscreen.sh
+++ b/scripts/android/run_waylandcraft_fullscreen.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-key WaylandCraft fullscreen launcher for DroidSpaces/Termux-X11.
+# Run inside the Ubuntu container from the repository root:
+#   ./scripts/android/run_waylandcraft_fullscreen.sh
+#
+# Optional env:
+#   DISPLAY=:0
+#   WLC_PULSE_SERVER=/run/user/1000/pulse/native
+#   WLC_TERMINATE_EXISTING=1
+#   WLC_FULLSCREEN_MODE=root    # root | portrait | custom
+#   WLC_WIDTH=2272 WLC_HEIGHT=1080
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+DISPLAY="${DISPLAY:-:0}"
+PULSE_SERVER="${WLC_PULSE_SERVER:-${PULSE_SERVER:-/run/user/1000/pulse/native}}"
+TERMINATE_EXISTING="${WLC_TERMINATE_EXISTING:-1}"
+FULLSCREEN_MODE="${WLC_FULLSCREEN_MODE:-root}"
+
+log() { printf '%s\n' "$*"; }
+
+get_root_geometry() {
+  DISPLAY="$DISPLAY" xwininfo -root 2>/dev/null | awk '
+    /Width:/ {w=$2}
+    /Height:/ {h=$2}
+    END { if (w && h) print w " " h; else exit 1 }
+  '
+}
+
+if [ "$FULLSCREEN_MODE" = "custom" ]; then
+  WIDTH="${WLC_WIDTH:?WLC_FULLSCREEN_MODE=custom 时必须设置 WLC_WIDTH}"
+  HEIGHT="${WLC_HEIGHT:?WLC_FULLSCREEN_MODE=custom 时必须设置 WLC_HEIGHT}"
+elif [ "$FULLSCREEN_MODE" = "portrait" ]; then
+  # Some Termux-X11 sessions expose a portrait-sized X11 root even while Android is rotated.
+  # Use this only if root mode looks wrong on your device.
+  WIDTH="${WLC_WIDTH:-1080}"
+  HEIGHT="${WLC_HEIGHT:-2277}"
+else
+  read -r WIDTH HEIGHT < <(get_root_geometry)
+fi
+
+log "🖥️ DISPLAY=$DISPLAY"
+log "🖥️ target fullscreen size=${WIDTH}x${HEIGHT} mode=$FULLSCREEN_MODE"
+log "🔊 PULSE_SERVER=$PULSE_SERVER"
+
+# Set Minecraft options before launching so LWJGL/Minecraft creates the right framebuffer.
+if [ -f run/options.txt ]; then
+  python3 - <<PY
+from pathlib import Path
+p = Path('run/options.txt')
+text = p.read_text()
+repls = {
+    'fullscreen:': 'fullscreen:true',
+    'exclusiveFullscreen:': 'exclusiveFullscreen:false',
+    'overrideWidth:': 'overrideWidth:$WIDTH',
+    'overrideHeight:': 'overrideHeight:$HEIGHT',
+}
+lines = []
+seen = set()
+for line in text.splitlines():
+    replaced = False
+    for prefix, value in repls.items():
+        if line.startswith(prefix):
+            lines.append(value)
+            seen.add(prefix)
+            replaced = True
+            break
+    if not replaced:
+        lines.append(line)
+for prefix, value in repls.items():
+    if prefix not in seen:
+        lines.append(value)
+p.write_text('\n'.join(lines) + '\n')
+PY
+else
+  mkdir -p run
+  {
+    echo 'fullscreen:true'
+    echo 'exclusiveFullscreen:false'
+    echo "overrideWidth:$WIDTH"
+    echo "overrideHeight:$HEIGHT"
+  } > run/options.txt
+fi
+
+if [ "$TERMINATE_EXISTING" = "1" ]; then
+  log "🧹 stopping existing runClient/Minecraft if any..."
+  pkill -f 'net.fabricmc.devlaunchinjector.Main|gradle-wrapper.jar runClient' 2>/dev/null || true
+  sleep 2
+fi
+
+# Helper to force the X11 window to the exact root size after launch.
+mkdir -p tools
+cat > tools/x_move_resize.py <<'PY'
+#!/usr/bin/env python3
+import ctypes, sys
+lib = ctypes.CDLL('libX11.so.6')
+lib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+lib.XOpenDisplay.restype = ctypes.c_void_p
+lib.XMoveResizeWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.c_int, ctypes.c_int, ctypes.c_uint, ctypes.c_uint]
+lib.XMapRaised.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+lib.XRaiseWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+lib.XFlush.argtypes = [ctypes.c_void_p]
+lib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+if len(sys.argv) != 7:
+    raise SystemExit(f"usage: {sys.argv[0]} DISPLAY WINDOW_HEX X Y WIDTH HEIGHT")
+dpy = lib.XOpenDisplay(sys.argv[1].encode())
+if not dpy:
+    raise SystemExit('XOpenDisplay failed')
+win = int(sys.argv[2], 0)
+x, y, w, h = map(int, sys.argv[3:7])
+lib.XMoveResizeWindow(dpy, win, x, y, w, h)
+lib.XMapRaised(dpy, win)
+lib.XRaiseWindow(dpy, win)
+lib.XFlush(dpy)
+lib.XCloseDisplay(dpy)
+print(f'moved/resized 0x{win:x} to {w}x{h}+{x}+{y}')
+PY
+chmod +x tools/x_move_resize.py
+
+log "🚀 starting WaylandCraft..."
+(
+  source ~/.cargo/env 2>/dev/null || true
+  export DISPLAY="$DISPLAY"
+  export LIBRARY_PATH=/home/user/.local/lib
+  export LD_LIBRARY_PATH="$ROOT_DIR/native/target/debug:/home/user/.local/lib:${LD_LIBRARY_PATH:-}"
+  export PULSE_SERVER="$PULSE_SERVER"
+  export ALSOFT_DRIVERS=pulse
+  exec ./gradlew runClient --console=plain
+) &
+PID=$!
+log "📌 launcher pid=$PID"
+
+# Wait for the Minecraft X11 window, then force exact geometry a few times.
+log "⏳ waiting for Minecraft window..."
+WIN=""
+for i in $(seq 1 90); do
+  WIN=$(DISPLAY="$DISPLAY" xwininfo -root -tree 2>/dev/null | awk '/Minecraft\*/ {print $1; exit}') || true
+  if [ -n "$WIN" ]; then
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "$WIN" ]; then
+  log "⚠️ 90 秒内没有找到 Minecraft 窗口。runClient 仍在后台运行，pid=$PID"
+  wait "$PID"
+  exit $?
+fi
+
+log "✅ found Minecraft window: $WIN"
+for i in $(seq 1 8); do
+  python3 tools/x_move_resize.py "$DISPLAY" "$WIN" 0 0 "$WIDTH" "$HEIGHT" >/dev/null 2>&1 || true
+  sleep 1
+done
+
+log "✅ fullscreen applied"
+DISPLAY="$DISPLAY" xwininfo -id "$WIN" -stats 2>/dev/null | grep -E 'Width:|Height:|-geometry' || true
+log ""
+log "提示：如果 Android 软键盘/导航栏仍遮挡，请在 Termux-X11 内手动关闭 Show keyboard，并打开 Immersive/Fullscreen/Hide system bars。"
+log "按 Ctrl+C 会停止等待，但 Minecraft/Gradle 可能继续运行；如需结束可运行：pkill -f 'net.fabricmc.devlaunchinjector.Main|gradle-wrapper.jar runClient'"
+
+wait "$PID"

--- a/scripts/android/termux_audio_x11_setup.sh
+++ b/scripts/android/termux_audio_x11_setup.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Termux / Android host-side audio + X11 bootstrap
+# - Starts or reuses PulseAudio
+# - Loads AAudio sink
+# - Exposes PulseAudio over TCP for the Ubuntu container
+# - Starts termux-x11 only if :0 is not already running
+
+X11_DISPLAY="${X11_DISPLAY:-:0}"
+PULSE_PORT="${PULSE_PORT:-4713}"
+PULSE_ACL="${PULSE_ACL:-127.0.0.1,192.168.2.0/24,10.0.0.0/8,172.16.0.0/12}"
+AAUDIO_SINK_NAME="${AAUDIO_SINK_NAME:-AAudio_sink}"
+
+required=(pulseaudio pactl pacmd termux-x11 grep awk sleep id pkill pgrep)
+missing=()
+for cmd in "${required[@]}"; do
+  command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+done
+
+if [ "${#missing[@]}" -ne 0 ]; then
+  echo "❌ 缺少依赖："
+  printf '   %s\n' "${missing[@]}"
+  exit 1
+fi
+
+# Do not use $PREFIX/tmp directly if it was created by root. PulseAudio refuses
+# XDG_RUNTIME_DIR owned by a different uid, which commonly happens after running
+# Termux scripts via su/root once.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$HOME/.termux-pulse-runtime}"
+mkdir -p "$XDG_RUNTIME_DIR"
+if [ ! -O "$XDG_RUNTIME_DIR" ]; then
+  echo "⚠️ XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR 不是当前用户所有，改用用户目录 runtime。"
+  export XDG_RUNTIME_DIR="$HOME/.termux-pulse-runtime"
+  mkdir -p "$XDG_RUNTIME_DIR"
+fi
+chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+
+# Avoid stale root-owned PulseAudio socket/cookie from previous runs.
+if [ -e "$XDG_RUNTIME_DIR/pulse" ] && [ ! -O "$XDG_RUNTIME_DIR/pulse" ]; then
+  echo "⚠️ $XDG_RUNTIME_DIR/pulse 不是当前用户所有；请在 Termux 普通用户下删除或换 runtime。"
+  export XDG_RUNTIME_DIR="$HOME/.termux-pulse-runtime-$$"
+  mkdir -p "$XDG_RUNTIME_DIR"
+  chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+fi
+
+cleanup_pulseaudio_runtime() {
+  # Termux PulseAudio can leave a stale pid/socket in $XDG_RUNTIME_DIR/pulse;
+  # then new daemon startup fails with: pa_pid_file_create() failed / Daemon already running.
+  rm -f "$XDG_RUNTIME_DIR/pulse/pid" \
+        "$XDG_RUNTIME_DIR/pulse/native" \
+        "$XDG_RUNTIME_DIR/pulse/cli" \
+        "$XDG_RUNTIME_DIR/pulse/lock" 2>/dev/null || true
+}
+
+start_pulseaudio() {
+  echo "🚀 正在启动 PulseAudio..."
+  pulseaudio -k 2>/dev/null || true
+  pkill pulseaudio 2>/dev/null || true
+  sleep 0.8
+  cleanup_pulseaudio_runtime
+  pulseaudio --start --exit-idle-time=-1 --disallow-exit || true
+  sleep 1
+  if ! pactl info >/dev/null 2>&1; then
+    echo "⚠️ --start 未连上，尝试前台 daemonize=no 后台启动..."
+    cleanup_pulseaudio_runtime
+    pulseaudio --daemonize=no --log-target=stderr --exit-idle-time=-1 --disallow-exit >/tmp/termux-pulseaudio.log 2>&1 &
+    sleep 1.5
+  fi
+}
+
+if pgrep -x pulseaudio >/dev/null 2>&1; then
+  echo "ℹ️ 检测到 PulseAudio 进程，先检查 pactl 连接..."
+else
+  start_pulseaudio
+fi
+
+if ! pactl info >/dev/null 2>&1; then
+  echo "⚠️ 现有 PulseAudio 进程不可用，尝试重启..."
+  start_pulseaudio
+fi
+
+if ! pactl info >/dev/null 2>&1; then
+  echo "❌ PulseAudio daemon 未就绪。下面是前台调试输出前 80 行："
+  timeout 8 pulseaudio -vvv --exit-idle-time=-1 --disallow-exit 2>&1 | sed -n '1,80p' || true
+  exit 1
+fi
+
+# Ensure AAudio sink exists and becomes default.
+if pactl list sinks short | grep -q "[[:space:]]${AAUDIO_SINK_NAME}[[:space:]]"; then
+  echo "ℹ️ 已找到 AAudio sink: ${AAUDIO_SINK_NAME}"
+else
+  echo "🚀 正在加载 module-aaudio-sink..."
+  pactl load-module module-aaudio-sink >/dev/null 2>&1 || true
+  sleep 0.5
+fi
+
+AAUDIO_SINK=$(pactl list sinks short | awk -v n="$AAUDIO_SINK_NAME" '$2==n {print $2; exit}')
+if [ -n "$AAUDIO_SINK" ]; then
+  pactl set-default-sink "$AAUDIO_SINK"
+  echo "✅ 默认音频设备设置为: $AAUDIO_SINK"
+else
+  echo "⚠️ 未找到 AAudio sink，当前 sinks："
+  pactl list sinks short
+fi
+
+# Expose PulseAudio to the Ubuntu container over TCP.
+load_tcp_module() {
+  local args="$1"
+  local out
+  out=$(pactl load-module module-native-protocol-tcp $args 2>&1) && {
+    echo "✅ native-protocol-tcp 已加载，module id: $out"
+    return 0
+  }
+  echo "⚠️ 加载 TCP 参数失败: $args"
+  echo "   pactl: $out"
+  return 1
+}
+
+if pactl list modules short | grep -q native-protocol-tcp; then
+  echo "ℹ️ native-protocol-tcp 已加载"
+else
+  echo "🚀 正在加载 module-native-protocol-tcp..."
+  load_tcp_module "auth-ip-acl=$PULSE_ACL auth-anonymous=1" || \
+  load_tcp_module "auth-anonymous=1" || {
+    echo "❌ 无法加载 module-native-protocol-tcp。检查模块文件："
+    ls "$PREFIX"/lib/pulse-*/modules/module-native-protocol-tcp.so 2>/dev/null || true
+  }
+fi
+
+# Verify TCP listener if ss/netstat is available.
+if command -v ss >/dev/null 2>&1; then
+  echo "\n=== TCP listeners 4713 ==="
+  ss -ltnp 2>/dev/null | grep ':4713' || echo "⚠️ 没看到 4713 监听"
+elif command -v netstat >/dev/null 2>&1; then
+  echo "\n=== TCP listeners 4713 ==="
+  netstat -ltnp 2>/dev/null | grep ':4713' || echo "⚠️ 没看到 4713 监听"
+fi
+
+# Start termux-x11 only if not already running for this display.
+if pgrep -f "termux-x11 ${X11_DISPLAY}" >/dev/null 2>&1; then
+  echo "ℹ️ termux-x11 (${X11_DISPLAY}) 已经在运行，跳过启动。"
+else
+  if [ -n "${DISPLAY:-}" ] && [ "$DISPLAY" = "$X11_DISPLAY" ]; then
+    echo "ℹ️ DISPLAY 已经是 ${X11_DISPLAY}，不重复启动 termux-x11。"
+  else
+    echo "🖥️ 正在启动 termux-x11 (${X11_DISPLAY})..."
+    termux-x11 "$X11_DISPLAY" -dpi 315 >/dev/null 2>&1 &
+    sleep 1
+  fi
+fi
+
+# Hide Android soft keyboard after Termux-X11 is up. This prevents the IME
+# overlay from covering the lower half of the fullscreen X11 window.
+if command -v termux-keyboard-hide >/dev/null 2>&1; then
+  termux-keyboard-hide >/dev/null 2>&1 || true
+  echo "⌨️ 已调用 termux-keyboard-hide"
+fi
+if command -v input >/dev/null 2>&1; then
+  input keyevent KEYCODE_BACK >/dev/null 2>&1 || true
+  sleep 0.1
+  input keyevent KEYCODE_ESCAPE >/dev/null 2>&1 || true
+  echo "⌨️ 已发送 BACK/ESC 隐藏软键盘"
+elif command -v su >/dev/null 2>&1; then
+  su -c 'input keyevent KEYCODE_BACK; sleep 0.1; input keyevent KEYCODE_ESCAPE' >/dev/null 2>&1 || true
+  echo "⌨️ 已尝试通过 su 隐藏软键盘"
+fi
+
+echo "\n=== PulseAudio 状态 ==="
+pactl info | sed -n '1,20p'
+
+echo "\n=== sinks ==="
+pactl list sinks short
+
+echo "\n=== modules tcp/aaudio ==="
+pactl list modules short | grep -E 'aaudio|native-protocol-tcp' || true

--- a/scripts/android/termux_hide_keyboard.sh
+++ b/scripts/android/termux_hide_keyboard.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hide Android soft keyboard from Termux/Termux-X11.
+# Run this on the Termux Android host, not inside the Ubuntu container.
+# It tries non-root methods first, then root-only input-method commands if su works.
+
+say() { printf '%s\n' "$*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+say "⌨️  正在尝试隐藏 Android 软键盘..."
+
+# 1) Termux:API route. Works if termux-api app + package are installed.
+if have termux-keyboard-hide; then
+  termux-keyboard-hide >/dev/null 2>&1 || true
+  say "✅ 已调用 termux-keyboard-hide"
+fi
+
+# 2) Generic Android key events. BACK usually hides IME. ESC helps some X11/focused views.
+if have input; then
+  input keyevent KEYCODE_BACK >/dev/null 2>&1 || true
+  sleep 0.1
+  input keyevent KEYCODE_ESCAPE >/dev/null 2>&1 || true
+  say "✅ 已发送 Android BACK/ESC keyevent"
+elif have su; then
+  su -c 'input keyevent KEYCODE_BACK; sleep 0.1; input keyevent KEYCODE_ESCAPE' >/dev/null 2>&1 || true
+  say "✅ 已通过 su 发送 Android BACK/ESC keyevent"
+fi
+
+# 3) Root route: temporarily switch to a non-soft-keyboard IME if available.
+# This is conservative: only switches if a physical/null keyboard IME is already installed.
+if have su && su -c 'id -u' 2>/dev/null | grep -q '^0$'; then
+  CURRENT_IME=$(su -c 'settings get secure default_input_method' 2>/dev/null || true)
+  ENABLED_IME=$(su -c 'settings get secure enabled_input_methods' 2>/dev/null || true)
+
+  CANDIDATE_IME=$(printf '%s' "$ENABLED_IME" | tr ':' '\n' | grep -Ei 'NullKeyboard|AnySoftKeyboard.*physical|hardware|latin.*physical' | head -n1 || true)
+  if [ -n "$CANDIDATE_IME" ] && [ "$CANDIDATE_IME" != "$CURRENT_IME" ]; then
+    mkdir -p "$HOME/.termux-x11-state"
+    printf '%s\n' "$CURRENT_IME" > "$HOME/.termux-x11-state/previous_ime"
+    su -c "ime set '$CANDIDATE_IME'" >/dev/null 2>&1 || true
+    say "✅ 已切换到候选非软键盘 IME: $CANDIDATE_IME"
+    say "   原 IME 已保存到: $HOME/.termux-x11-state/previous_ime"
+  else
+    say "ℹ️ 未发现可自动切换的 Null/physical IME；保持当前输入法。"
+  fi
+fi
+
+say "完成。若软键盘仍显示，请在 Termux-X11 浮动菜单里手动关闭 Show keyboard。"

--- a/tools/x_move_resize.py
+++ b/tools/x_move_resize.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import ctypes, sys
+lib = ctypes.CDLL('libX11.so.6')
+lib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+lib.XOpenDisplay.restype = ctypes.c_void_p
+lib.XMoveResizeWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.c_int, ctypes.c_int, ctypes.c_uint, ctypes.c_uint]
+lib.XMapRaised.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+lib.XRaiseWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+lib.XFlush.argtypes = [ctypes.c_void_p]
+lib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+if len(sys.argv) != 7:
+    raise SystemExit(f"usage: {sys.argv[0]} DISPLAY WINDOW_HEX X Y WIDTH HEIGHT")
+dpy = lib.XOpenDisplay(sys.argv[1].encode())
+if not dpy:
+    raise SystemExit('XOpenDisplay failed')
+win = int(sys.argv[2], 0)
+x, y, w, h = map(int, sys.argv[3:7])
+lib.XMoveResizeWindow(dpy, win, x, y, w, h)
+lib.XMapRaised(dpy, win)
+lib.XRaiseWindow(dpy, win)
+lib.XFlush(dpy)
+lib.XCloseDisplay(dpy)
+print(f'moved/resized 0x{win:x} to {w}x{h}+{x}+{y}')


### PR DESCRIPTION
- Add Termux PulseAudio and Termux-X11 setup helpers
- Add one-key WaylandCraft launch scripts for DroidSpaces
- Add Chinese README with Android audio troubleshooting
- Fall back when EGL render node query is unavailable