### PR TITLE
Implement hover focus and auto keyboard grab features

### DIFF
--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -262,6 +262,10 @@ bind_java_type! {
             sig = (instance: jlong) -> jint,
             fn = cursor_shape,
         },
+        static extern fn input_activate_state {
+            sig = (instance: jlong) -> jboolean,
+            fn = input_activate_state,
+        },
         static extern fn keyboard_focus {
             sig = (instance: jlong, surface_handle: jlong),
             fn = keyboard_focus,
@@ -1204,6 +1208,16 @@ fn cursor_shape<'local>(
     };
 
     Ok(shape)
+}
+
+fn input_activate_state<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    instance: jlong,
+) -> Result<jboolean, BridgeError> {
+    let instance = jptr_to_instance!(instance, "inputActivateState")?;
+
+    Ok(instance.state.seat.text_input_active as jboolean)
 }
 
 fn keyboard_focus<'local>(

--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -22,6 +22,10 @@ use smithay::{
             zwp_relative_pointer_v1 as zwp_relpointer,
             zwp_relative_pointer_v1::ZwpRelativePointerV1,
         },
+        wayland_protocols::wp::text_input::zv3::server::{
+            zwp_text_input_manager_v3::{self, ZwpTextInputManagerV3},
+            zwp_text_input_v3::{self, ZwpTextInputV3},
+        },
         wayland_server::{
             Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
             Resource,
@@ -46,7 +50,9 @@ use xkbcommon::xkb::{self, Keymap};
 pub struct WLCSeatState {
     pub pointers: Vec<WlPointer>,
     pub keyboards: Vec<WlKeyboard>,
+    pub text_inputs: Vec<ZwpTextInputV3>,
     pub kb_active: bool,
+    pub text_input_active: bool,
     pub pressed_keys: HashSet<u32>,
     pub keymap: Keymap,
     pub keymap_file: SealedFile,
@@ -93,6 +99,15 @@ pub struct WLCKeyboardData {
 
 type WLCKeyboard = Arc<Mutex<WLCKeyboardData>>;
 
+pub struct WLCTextInputData {
+    enabled: bool,
+    // Unlike WLCKeyboardData, we could use focus between different clients,
+    // but from UX perspective I think it should be focused only on active client.
+    focus: Option<WlSurface>,
+}
+
+type WLCTextInput = Arc<Mutex<WLCTextInputData>>;
+
 // Keyboard RMLVO keymap specifier
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Default)]
@@ -138,6 +153,15 @@ where
     f(data);
 }
 
+fn with_text_input_data<F>(text_input: &ZwpTextInputV3, f: F)
+where
+    F: FnOnce(&mut WLCTextInputData),
+{
+    let mut guard = text_input.data::<WLCTextInput>().unwrap().lock().unwrap();
+    let data = guard.deref_mut();
+    f(data);
+}
+
 fn create_keymap_file(keymap: &Keymap) -> SealedFile {
     let keymap_str = keymap.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1);
     SealedFile::with_content(
@@ -168,7 +192,9 @@ impl WLCSeatState {
         WLCSeatState {
             pointers: vec![],
             keyboards: vec![],
+            text_inputs: vec![],
             kb_active: false,
+            text_input_active: false,
             pressed_keys: HashSet::new(),
             keymap,
             keymap_file,
@@ -183,6 +209,7 @@ impl WLCSeatState {
         disp.create_global::<WLCState, ZwpRelativePointerManagerV1, ()>(1, ());
         disp.create_global::<WLCState, ZwpPointerConstraintsV1, ()>(1, ());
         disp.create_global::<WLCState, WpCursorShapeManagerV1, ()>(2, ());
+        disp.create_global::<WLCState, ZwpTextInputManagerV3, ()>(1, ());
     }
 
     fn pointer_frame(&self, pointer: &WlPointer) {
@@ -381,6 +408,36 @@ impl WLCSeatState {
 
             self.send_modifiers(keyboard, serial);
         });
+
+        // Update text inputs
+        let mut input_active = false;
+        self.for_all_text_inputs(|text_input, data| {
+            let text_input_client = text_input.client().unwrap();
+
+            if text_input_client != client {
+                // only active client is able to be focused
+                if let Some(focus) = &data.focus {
+                    text_input.leave(focus);
+                    data.focus = None;
+                }
+                return;
+            }
+
+            if let Some(focus) = &data.focus {
+                if *focus == surface {
+                    // Surface already focused
+                    input_active = input_active || data.enabled;
+                    return;
+                }
+                text_input.leave(focus);
+                data.focus = None;
+            }
+
+            text_input.enter(&surface);
+            data.focus = Some(surface.clone());
+            input_active = true;
+        });
+        self.text_input_active = input_active;
     }
 
     fn serialize_pressed_keys(&self) -> Vec<u8> {
@@ -457,6 +514,15 @@ impl WLCSeatState {
                 data.focus = None;
             }
         });
+
+        // Update text inputs
+        self.text_input_active = false;
+        self.for_all_text_inputs(|text_input, data| {
+            if let Some(focus) = &data.focus {
+                text_input.leave(focus);
+                data.focus = None;
+            }
+        });
     }
 
     pub fn keyboard_key(&self, key: u32, state: KeyState) {
@@ -523,6 +589,15 @@ impl WLCSeatState {
     {
         for keyboard in &self.keyboards {
             with_keyboard_data(keyboard, |data| f(keyboard, data));
+        }
+    }
+
+    fn for_all_text_inputs<F>(&self, mut f: F)
+    where
+        F: FnMut(&ZwpTextInputV3, &mut WLCTextInputData),
+    {
+        for text_input in &self.text_inputs {
+            with_text_input_data(text_input, |data| f(text_input, data));
         }
     }
 
@@ -1049,5 +1124,91 @@ impl Dispatch<WpCursorShapeDeviceV1, WLCCursorShapeDevice> for WLCState {
             }
             _ => unreachable!(),
         }
+    }
+}
+
+impl GlobalDispatch<ZwpTextInputManagerV3, ()> for WLCState {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwpTextInputManagerV3>,
+        _data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl Dispatch<ZwpTextInputManagerV3, ()> for WLCState {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        _resource: &ZwpTextInputManagerV3,
+        request: zwp_text_input_manager_v3::Request,
+        _data: &(),
+        _disp: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            zwp_text_input_manager_v3::Request::GetTextInput { id, .. } => {
+                let text_input_data = WLCTextInputData {
+                    enabled: false,
+                    focus: None,
+                };
+                let text_input_data = Arc::new(Mutex::new(text_input_data));
+
+                let text_input: ZwpTextInputV3 =
+                    data_init.init(id, text_input_data.clone());
+
+                state.seat.text_inputs.push(text_input);
+            }
+            zwp_text_input_manager_v3::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<ZwpTextInputV3, WLCTextInput> for WLCState {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        text_input: &ZwpTextInputV3,
+        request: zwp_text_input_v3::Request,
+        _data: &WLCTextInput,
+        _disp: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            zwp_text_input_v3::Request::Enable => {
+                with_text_input_data(text_input, |data| data.enabled = true);
+            }
+            zwp_text_input_v3::Request::Disable => {
+                with_text_input_data(text_input, |data| data.enabled = false);
+            }
+            // actually all of changes should be applied here, not immediately
+            zwp_text_input_v3::Request::Commit => {
+                with_text_input_data(text_input, |data| {
+                    if let Some(_focus) = &data.focus {
+                        state.seat.text_input_active = data.enabled;
+                    }
+                });
+            }
+            zwp_text_input_v3::Request::Destroy => {}
+            zwp_text_input_v3::Request::SetContentType { .. } => {}
+            zwp_text_input_v3::Request::SetCursorRectangle { .. } => {}
+            zwp_text_input_v3::Request::SetSurroundingText { .. } => {}
+            zwp_text_input_v3::Request::SetTextChangeCause { .. } => {}
+            _ => unreachable!(),
+        }
+    }
+
+    fn destroyed(
+        state: &mut Self,
+        _client: ClientId,
+        text_input_resource: &ZwpTextInputV3,
+        _data: &WLCTextInput,
+    ) {
+        state.seat.text_inputs.retain(|p| p != text_input_resource);
     }
 }

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -95,6 +95,7 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 	public DisplayHitResult hoveredDisplay = null;
 	
 	public KeyboardCaptureMode keyboardCaptureMode = KeyboardCaptureMode.NONE;
+	private boolean textInputActivated = false;
 	
 	public PointerCapture pointerCapture = null;
 	
@@ -354,6 +355,18 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 				bridge.dndCancel();
 			}
 		}
+		
+		if(settings.getAutoKeyboardGrab()) {
+			boolean inputActivateState = bridge.getInputActivateState();
+			if(inputActivateState) {
+			    if (!textInputActivated) {
+					enableKeyboardCapture(false);
+				}
+			} else if(keyboardCaptureMode == KeyboardCaptureMode.CAPTURE && textInputActivated) {
+				disableKeyboardCapture();
+			}
+			textInputActivated = inputActivateState;
+		}
 	}
 	
 	private void updateOutputSize(boolean inWMScreen) {
@@ -448,7 +461,14 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		// Check for player reach
 		if(finalHitResult != null && !finalHitResult.position.closerThan(pos, Minecraft.getInstance().player.blockInteractionRange())) finalHitResult = null;
 		
-		if(!pointerGrabs.isExclusiveGrabActive()) hoveredDisplay = finalHitResult;
+		if(!pointerGrabs.isExclusiveGrabActive()) {
+			hoveredDisplay = finalHitResult;
+			
+			if(settings.getHoverFocus() && hoveredDisplay != null && hoveredDisplay.dist >= 0) {
+				WLCAbstractWindow window = hoveredDisplay.target.window;
+				if(window instanceof WLCToplevel) bridge.focusSurface((WLCToplevel) window);
+			}
+		}
 		
 		// Check for pointer grab and short-circuit if any
 		if(pointerGrabs.isGrabActive()) {

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -283,7 +283,7 @@ public class WaylandCraftBridge {
 			toplevel.appID = toplevelAppID(toplevel.getHandle());
 			
 			if(ArrayUtils.contains(minimizeRequests, handle)) toplevel.requests.minimize = true;
-			if(ArrayUtils.contains(maximizeRequests, handle)) toplevel.requests.maximize= true;
+			if(ArrayUtils.contains(maximizeRequests, handle)) toplevel.requests.maximize = true;
 			if(ArrayUtils.contains(unmaximizeRequests, handle)) toplevel.requests.unmaximize = true;
 			if(ArrayUtils.contains(fullscreenRequests, handle)) toplevel.requests.fullscreen = true;
 			if(ArrayUtils.contains(unfullscreenRequests, handle)) toplevel.requests.unfullscreen = true;
@@ -511,6 +511,10 @@ public class WaylandCraftBridge {
 	
 	public CursorShape getCursorShape() {
 		return CursorShape.fromId(cursorShape(instance));
+	}
+	
+	public boolean getInputActivateState() {
+		return inputActivateState(instance);
 	}
 	
 	public void focusSurface(@Nullable WLCToplevel toplevel) {
@@ -757,6 +761,9 @@ public class WaylandCraftBridge {
 	
 	// Get active cursor image
 	private static native int cursorShape(long instance);
+	
+	// Get text input activate state
+	private static native boolean inputActivateState(long instance);
 	
 	// Set keyboard focus to a wayland surface. The handle may be 0 to unfocus any surfaces
 	private static native void keyboardFocus(long instance, long surfaceHandle);

--- a/src/main/java/dev/evvie/waylandcraft/gui/WaylandCraftSettingsScreen.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/WaylandCraftSettingsScreen.java
@@ -71,6 +71,8 @@ public class WaylandCraftSettingsScreen extends Screen {
 		
 		createIntSettingsWidget("pixelsPerBlock", Component.literal("Window display pixels per block"));
 		createBooleanSettingsWidget("windowAntialiasing", Component.literal("Window in world antialiasing"));
+		createBooleanSettingsWidget("hoverFocus", Component.literal("Focus window on cursor hover"));
+		createBooleanSettingsWidget("autoKeyboardGrab", Component.literal("Grab keyboard on app request"));
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
@@ -20,6 +20,8 @@ public class WaylandCraftSettings {
 	
 	int pixelsPerBlock = 500;
 	boolean windowAntialiasing = false;
+	boolean hoverFocus = false;
+	boolean autoKeyboardGrab = false;
 	
 	/* This is where the getters go */
 	
@@ -29,6 +31,14 @@ public class WaylandCraftSettings {
 	
 	public boolean getAntialiasing() {
 		return windowAntialiasing;
+	}
+	
+	public boolean getHoverFocus() {
+		return hoverFocus;
+	}
+	
+	public boolean getAutoKeyboardGrab() {
+		return autoKeyboardGrab;
 	}
 	
 	/* Methods to modifiy settings by name */


### PR DESCRIPTION
This PR implements 2 small but very quality of life improvement features:

1. **Hover focus**: Changes current window focus depending on where your crosshair is. It's implemented in some other compositors so nothing actually new.

2. **Auto keyboard grab**: It's more interesting feature, it captures your keyboard if application requests for it (SDL_StartTextInput and some others like inside qt or chromium).
   Keyboard capturing automatically removes when focus changes to another app that doesn't need input.
   It does soft keyboard grab so you can use escape to quit from this.
   This was also done for some applications like KDE apps, they requests for keyborad when it's not really needed at the moment (like Ark).
   
   It also makes me found a bug: when you use movement keys and you activate keyboard capture, game continues to think you're holding these keys. I don't know how to fix this and anyways it should be fixed in other PR.

BTW I'm neither Minecraft mods nor Wayland compositors developer so feel free to criticize possible mistakes.