### PR TITLE
Implement focus on hover

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -484,6 +484,11 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 			if(keyboardCaptureMode != KeyboardCaptureMode.NONE && bridge.maybeLockPointer(surface)) {
 				pointerCapture = new PointerCapture(surface, rel.x, rel.y);
 			}
+			
+			// Focus on hover
+			if(settings.getFocusOnHover() && hoveredDisplay.target.window instanceof WLCToplevel toplevel) {
+				bridge.focusSurface(toplevel);
+			}
 		}
 		else {
 			bridge.sendMotionOutside();

--- a/src/main/java/dev/evvie/waylandcraft/gui/WaylandCraftSettingsScreen.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/WaylandCraftSettingsScreen.java
@@ -3,6 +3,7 @@ package dev.evvie.waylandcraft.gui;
 import java.util.ArrayList;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.settings.WaylandCraftSettings;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.ScrollableLayout;
 import net.minecraft.client.gui.components.StringWidget;
@@ -69,8 +70,9 @@ public class WaylandCraftSettingsScreen extends Screen {
 	private void createSettings() {
 		settingsWidgets.clear();
 		
-		createIntSettingsWidget("pixelsPerBlock", Component.literal("Window display pixels per block"));
-		createBooleanSettingsWidget("windowAntialiasing", Component.literal("Window in world antialiasing"));
+		createIntSettingsWidget(WaylandCraftSettings.PIXELS_PER_BLOCK, Component.literal("Window display pixels per block"));
+		createBooleanSettingsWidget(WaylandCraftSettings.WINDOW_ANTIALIASING, Component.literal("Window in world antialiasing"));
+		createBooleanSettingsWidget(WaylandCraftSettings.FOCUS_ON_HOVER, Component.literal("Focus windows when hovered"));
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
@@ -20,6 +20,12 @@ public class WaylandCraftSettings {
 	
 	int pixelsPerBlock = 500;
 	boolean windowAntialiasing = false;
+	boolean focusOnHover = false;
+	
+	/* This is where the field names go to avoid typos */
+	public static final String PIXELS_PER_BLOCK = "pixelsPerBlock";
+	public static final String WINDOW_ANTIALIASING = "windowAntialiasing";
+	public static final String FOCUS_ON_HOVER = "focusOnHover";
 	
 	/* This is where the getters go */
 	
@@ -29,6 +35,10 @@ public class WaylandCraftSettings {
 	
 	public boolean getAntialiasing() {
 		return windowAntialiasing;
+	}
+	
+	public boolean getFocusOnHover() {
+		return focusOnHover;
 	}
 	
 	/* Methods to modifiy settings by name */


### PR DESCRIPTION
Adds a new setting which when enabled automatically gives keyboard focus to the currently hovered window display. This addresses #84 