### PR TITLE
Fix mouse scroll

### DIFF
--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -319,6 +319,9 @@ impl WLCSeatState {
     }
 
     pub fn pointer_axis(&self, axis: Axis, value: f64) {
+        let val120 = (value * 120.0).floor() as i32;
+        if val120 == 0 { return }
+
         self.for_all_pointers(|pointer, data| {
             if data.focus.is_some() {
                 let version = pointer.version();
@@ -326,8 +329,7 @@ impl WLCSeatState {
                     pointer.axis_source(AxisSource::Wheel);
                 }
                 if version >= wl_pointer::EVT_AXIS_VALUE120_SINCE {
-                    let value = value * 120.0;
-                    pointer.axis_value120(axis, value.floor() as i32);
+                    pointer.axis_value120(axis, val120);
                 } else if version >= wl_pointer::EVT_AXIS_DISCRETE_SINCE {
                     pointer.axis_discrete(axis, value.floor() as i32);
                 }

--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -319,9 +319,19 @@ impl WLCSeatState {
     }
 
     pub fn pointer_axis(&self, axis: Axis, value: f64) {
+        if value == 0.0 {
+            return;
+        }
         self.for_all_pointers(|pointer, data| {
             if data.focus.is_some() {
-                pointer.axis(get_time(), axis, value);
+                let version = pointer.version();
+                if version >= wl_pointer::EVT_AXIS_VALUE120_SINCE {
+                    let value = value * 120.0;
+                    pointer.axis_value120(axis, value.floor() as i32);
+                } else if version >= wl_pointer::EVT_AXIS_DISCRETE_SINCE {
+                    pointer.axis_discrete(axis, value.floor() as i32);
+                }
+                pointer.axis(get_time(), axis, value * 10.0);
                 self.pointer_frame(pointer);
             }
         });

--- a/native/src/seat.rs
+++ b/native/src/seat.rs
@@ -28,7 +28,7 @@ use smithay::{
             backend::ClientId,
             protocol::{
                 wl_keyboard::{self, KeyState, KeymapFormat, WlKeyboard},
-                wl_pointer::{self, Axis, ButtonState, WlPointer},
+                wl_pointer::{self, Axis, AxisSource, ButtonState, WlPointer},
                 wl_seat::{self, WlSeat},
                 wl_surface::WlSurface,
             },
@@ -319,12 +319,12 @@ impl WLCSeatState {
     }
 
     pub fn pointer_axis(&self, axis: Axis, value: f64) {
-        if value == 0.0 {
-            return;
-        }
         self.for_all_pointers(|pointer, data| {
             if data.focus.is_some() {
                 let version = pointer.version();
+                if version >= wl_pointer::EVT_AXIS_SOURCE_SINCE {
+                    pointer.axis_source(AxisSource::Wheel);
+                }
                 if version >= wl_pointer::EVT_AXIS_VALUE120_SINCE {
                     let value = value * 120.0;
                     pointer.axis_value120(axis, value.floor() as i32);

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -584,9 +584,8 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		if(hoveredDisplay != null) {
 			if(hoveredDisplay.dist < 0) return true;
 			
-			// Multiplication by -10 is the inverse transformation from what GLFW does on wayland
-			bridge.sendScroll(0, -scrollY * 10);
-			bridge.sendScroll(1, -scrollX * 10);
+			bridge.sendScroll(0, -scrollY);
+			bridge.sendScroll(1, -scrollX);
 			
 			WLCAbstractWindow window = hoveredDisplay.target.window;
 			if(window instanceof WLCToplevel) bridge.focusSurface((WLCToplevel) window);

--- a/src/main/java/dev/evvie/waylandcraft/gui/WindowManagerScreen.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/WindowManagerScreen.java
@@ -560,8 +560,8 @@ public class WindowManagerScreen extends Screen {
 		HoveredSurface hovered = surfaceUnderPointer(mouseX, mouseY);
 		
 		if(hovered != null) {
-			wlc.bridge.sendScroll(0, -scrollY * 10);
-			wlc.bridge.sendScroll(1, -scrollX * 10);
+			wlc.bridge.sendScroll(0, -scrollY);
+			wlc.bridge.sendScroll(1, -scrollX);
 			return true;
 		}
 		


### PR DESCRIPTION
Some apps like Zed ignores wl_pointer.axis event.
I saw Weston implementation, they send axis_discrete before so that works.

Because axis_discrete is deprecated in wl_pointer version 8, it sends axis_value120 for newer clients.