### PR TITLE
Implement wp_presentation/presentation_time

### DIFF
--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -518,7 +518,7 @@ fn send_presentation<'local>(
     refresh_rate: jint,
 ) -> Result<(), BridgeError> {
     let instance = jptr_to_instance!(instance, "sendPresentation")?;
-    let refresh = Refresh::fixed(Duration::from_secs_f64(1.0 / refresh_rate as f64));
+    let refresh = Refresh::Fixed(Duration::from_secs_f64(1.0 / refresh_rate as f64));
     let presentation_time = Duration::from_nanos(presentation_time as u64);
 
     for surface in &instance.bridge.surfaces {

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -31,8 +31,8 @@ use smithay::{
     utils::{Logical, Point, Size},
     wayland::{
         compositor::{
-            BufferAssignment, SubsurfaceCachedState, SurfaceAttributes,
-            SurfaceData, TraversalAction, with_states, Damage,
+            BufferAssignment, Damage, SubsurfaceCachedState, SurfaceAttributes,
+            SurfaceData, TraversalAction, with_states,
             with_states as with_surface_data, with_surface_tree_upward,
         },
         dmabuf::get_dmabuf,
@@ -518,20 +518,29 @@ fn send_presentation<'local>(
     refresh_rate: jint,
 ) -> Result<(), BridgeError> {
     let instance = jptr_to_instance!(instance, "sendPresentation")?;
-    let refresh = Refresh::Fixed(Duration::from_secs_f64(1.0 / refresh_rate as f64));
+    let refresh =
+        Refresh::Fixed(Duration::from_secs_f64(1.0 / refresh_rate as f64));
     let presentation_time = Duration::from_nanos(presentation_time as u64);
 
     for surface in &instance.bridge.surfaces {
         let mut callbacks = with_states(surface, |states| {
-            std::mem::take(&mut states
-                .cached_state
-                .get::<PresentationFeedbackCachedState>()
-                .current()
-                .callbacks)
+            std::mem::take(
+                &mut states
+                    .cached_state
+                    .get::<PresentationFeedbackCachedState>()
+                    .current()
+                    .callbacks,
+            )
         });
         let seq = 0; // As protocol said. We can't query refresh count
         for feedback in callbacks.drain(..) {
-            feedback.presented(&instance.state.output.output, presentation_time, refresh, seq, Kind::Vsync);
+            feedback.presented(
+                &instance.state.output.inner,
+                presentation_time,
+                refresh,
+                seq,
+                Kind::Vsync,
+            );
         }
     }
 

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -14,7 +14,10 @@ use jni::{
 use smithay::{
     backend::allocator::{Buffer, dmabuf::WeakDmabuf},
     reexports::{
-        wayland_protocols::xdg::shell::server::xdg_toplevel,
+        wayland_protocols::{
+            wp::presentation_time::server::wp_presentation_feedback::Kind,
+            xdg::shell::server::xdg_toplevel,
+        },
         wayland_server::{
             Resource,
             protocol::{
@@ -33,6 +36,7 @@ use smithay::{
             with_states as with_surface_data, with_surface_tree_upward,
         },
         dmabuf::get_dmabuf,
+        presentation::{PresentationFeedbackCachedState, Refresh},
         shell::xdg::{
             PopupSurface, SurfaceCachedState, ToplevelSurface,
             XdgToplevelSurfaceData,
@@ -44,6 +48,7 @@ use smithay::{
 };
 use std::ops::DerefMut;
 use std::path::PathBuf;
+use std::time::Duration;
 use thiserror::Error;
 
 #[allow(clippy::vec_box)]
@@ -113,6 +118,10 @@ bind_java_type! {
         static extern fn send_frame {
             sig = (surface_handle: jlong),
             fn = send_frame,
+        },
+        static extern fn send_presentation {
+            sig = (instance: jlong, presentation_time: jlong, refresh_rate: jint),
+            fn = send_presentation,
         },
         static extern fn update_surface_data {
             sig = (instance: jlong, surface: WLCSurface),
@@ -497,6 +506,34 @@ fn send_frame<'local>(
             c.done(get_time());
         }
     });
+
+    Ok(())
+}
+
+fn send_presentation<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    instance: jlong,
+    presentation_time: jlong,
+    refresh_rate: jint,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "sendPresentation")?;
+    let refresh = Refresh::fixed(Duration::from_secs_f64(1.0 / refresh_rate as f64));
+    let presentation_time = Duration::from_nanos(presentation_time as u64);
+
+    for surface in &instance.bridge.surfaces {
+        let mut callbacks = with_states(surface, |states| {
+            std::mem::take(&mut states
+                .cached_state
+                .get::<PresentationFeedbackCachedState>()
+                .current()
+                .callbacks)
+        });
+        let seq = 0; // As protocol said. We can't query refresh count
+        for feedback in callbacks.drain(..) {
+            feedback.presented(&instance.state.output.output, presentation_time, refresh, seq, Kind::Vsync);
+        }
+    }
 
     Ok(())
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,8 +6,9 @@ use crate::seat::WLCSeatState;
 use crate::xdg_spec::XDGSpecHelper;
 use smithay::{
     backend::allocator::dmabuf::Dmabuf,
-    delegate_compositor, delegate_dmabuf, delegate_shm, delegate_presentation,
-    delegate_single_pixel_buffer, delegate_viewporter, delegate_xdg_shell,
+    delegate_compositor, delegate_dmabuf, delegate_output,
+    delegate_presentation, delegate_shm, delegate_single_pixel_buffer,
+    delegate_viewporter, delegate_xdg_shell,
     reexports::{
         calloop::{self, EventLoop, generic::Generic as GenericEvent},
         wayland_protocols::xdg::shell::server::xdg_toplevel::ResizeEdge,
@@ -111,8 +112,8 @@ impl WLCState {
         let data = WLCDataState::new(&disp);
         data.create_global();
 
-        let output = WLCOutput::new(&disp);
-        output.create_global();
+        let output = WLCOutput::new();
+        output.inner.create_global::<WLCState>(&disp);
 
         Self {
             display_handle: disp.clone(),
@@ -353,3 +354,4 @@ delegate_viewporter!(WLCState);
 delegate_single_pixel_buffer!(WLCState);
 delegate_presentation!(WLCState);
 delegate_dmabuf!(WLCState);
+delegate_output!(WLCState);

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,7 +6,7 @@ use crate::seat::WLCSeatState;
 use crate::xdg_spec::XDGSpecHelper;
 use smithay::{
     backend::allocator::dmabuf::Dmabuf,
-    delegate_compositor, delegate_dmabuf, delegate_shm,
+    delegate_compositor, delegate_dmabuf, delegate_shm, delegate_presentation,
     delegate_single_pixel_buffer, delegate_viewporter, delegate_xdg_shell,
     reexports::{
         calloop::{self, EventLoop, generic::Generic as GenericEvent},
@@ -30,6 +30,7 @@ use smithay::{
             DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState,
             ImportNotifier,
         },
+        presentation::PresentationState,
         shell::xdg::{
             PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler,
             XdgShellState,
@@ -71,6 +72,7 @@ pub struct WLCState {
     pub xdg_state: XdgShellState,
     pub viewporter_state: ViewporterState,
     pub single_pixel_buffer_state: SinglePixelBufferState,
+    pub presentation_state: PresentationState,
     pub dmabuf_state: DmabufState,
     pub dmabuf_global: DmabufGlobal,
     pub requests: WindowRequests,
@@ -98,6 +100,7 @@ impl WLCState {
         let viewporter_state = ViewporterState::new::<WLCState>(&disp);
         let single_pixel_buffer_state =
             SinglePixelBufferState::new::<WLCState>(&disp);
+        let presentation_state = PresentationState::new::<WLCState>(&disp, 1);
 
         let mut dmabuf_state = DmabufState::new();
         let dmabuf_global = init_dmabuf(&disp, &mut dmabuf_state, egl);
@@ -119,6 +122,7 @@ impl WLCState {
             xdg_state,
             viewporter_state,
             single_pixel_buffer_state,
+            presentation_state,
             dmabuf_state,
             dmabuf_global,
             requests: WindowRequests::default(),
@@ -347,4 +351,5 @@ delegate_shm!(WLCState);
 delegate_xdg_shell!(WLCState);
 delegate_viewporter!(WLCState);
 delegate_single_pixel_buffer!(WLCState);
+delegate_presentation!(WLCState);
 delegate_dmabuf!(WLCState);

--- a/native/src/output.rs
+++ b/native/src/output.rs
@@ -1,5 +1,6 @@
 use crate::WLCState;
 use smithay::{
+    output::{self, Output, PhysicalProperties},
     reexports::wayland_server::{
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
         Resource,
@@ -9,8 +10,7 @@ use smithay::{
 };
 
 pub struct WLCOutput {
-    pub outputs: Vec<WlOutput>,
-    size: Size<i32, Logical>,
+    pub output: Output,
     // size of content area
     bounds: Size<i32, Logical>,
     display_handle: DisplayHandle,
@@ -18,9 +18,25 @@ pub struct WLCOutput {
 
 impl WLCOutput {
     pub fn new(display_handle: &DisplayHandle) -> Self {
-        WLCOutput {
-            outputs: vec![],
+        let output = Output::new(
+            "output-0".into(),
+            PhysicalProperties {
+                // "physical" size, not virtual
+                // I'll put (1920/500*10000, 1080/500*10000)mm here
+                // (assuming 1 block is 1 meter)
+                size: Size::new(38400, 21600),
+                subpixel: output::Subpixel::None,
+                make: "Virtual".into(),
+                model: "Monitor".into(),
+                serial_number: "V1RT".into(),
+            }
+        );
+        output.set_preferred(output::Mode {
             size: Size::new(1920, 1080),
+            refresh: 60000,
+        });
+        WLCOutput {
+            output,
             bounds: Size::new(1920, 1080),
             display_handle: display_handle.clone(),
         }
@@ -32,7 +48,7 @@ impl WLCOutput {
     }
 
     pub fn size(&self) -> Size<i32, Logical> {
-        self.size
+        self.output.preferred_mode().unwrap().size.to_logical(1)
     }
 
     pub fn bounds(&self) -> Size<i32, Logical> {
@@ -40,14 +56,12 @@ impl WLCOutput {
     }
 
     pub fn resize(&mut self, width: i32, height: i32) {
-        self.size = Size::new(width, height);
-        let flags = wl_output::Mode::Current;
-        for output in &self.outputs {
-            output.mode(flags, self.size.w, self.size.h, 0);
-            if output.version() >= 2 {
-                output.done();
-            }
-        }
+        let old_preferred = self.output.preferred_mode().unwrap();
+        self.output.set_preferred(output::Mode {
+            size: Size::new(width, height),
+            refresh: 60000,
+        });
+        self.output.delete_mode(old_preferred);
     }
 
     pub fn set_bounds(&mut self, width: i32, height: i32) {
@@ -65,28 +79,31 @@ impl GlobalDispatch<WlOutput, ()> for WLCState {
         data_init: &mut DataInit<'_, Self>,
     ) {
         let output: WlOutput = data_init.init(resource, ());
+        let state_output = &state.output.output;
 
         let flags = wl_output::Mode::Current;
-        let size = &state.output.size;
-        output.mode(flags, size.w, size.h, 0);
+        if let Some(mode) = state_output.current_mode() {
+            output.mode(flags, mode.size.w, mode.size.h, mode.refresh);
+        }
 
-        let location = (0, 0);
-        let physical = (0, 0);
-
+        let location = state_output.current_location();
+        let physical = state_output.physical_properties();
         output.geometry(
-            location.0,
-            location.1,
-            physical.0,
-            physical.1,
+            location.x,
+            location.y,
+            physical.size.w,
+            physical.size.h,
             wl_output::Subpixel::None,
-            "Virtual".into(),
-            "Monitor".into(),
-            wl_output::Transform::Normal,
+            //physical.subpixel,
+            physical.make,
+            physical.model,
+            wl_output::Transform::Normal
+            //state_output.current_transform()
         );
 
         if output.version() >= 4 {
-            output.name("output-0".into());
-            output.description("Virtual Output".into());
+            output.name(state_output.name());
+            output.description(state_output.description());
         }
 
         if output.version() >= 2 {

--- a/native/src/output.rs
+++ b/native/src/output.rs
@@ -1,24 +1,20 @@
 use crate::WLCState;
 use smithay::{
     output::{self, Output, PhysicalProperties},
-    reexports::wayland_server::{
-        Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
-        Resource,
-        protocol::wl_output::{self, WlOutput},
-    },
     utils::{Logical, Size},
+    wayland::output::OutputHandler,
 };
 
 pub struct WLCOutput {
-    pub output: Output,
+    pub inner: Output,
     // size of content area
     bounds: Size<i32, Logical>,
-    display_handle: DisplayHandle,
 }
 
 impl WLCOutput {
-    pub fn new(display_handle: &DisplayHandle) -> Self {
-        let output = Output::new(
+    pub fn new() -> Self {
+        let bounds = Size::new(1920, 1080);
+        let inner = Output::new(
             "output-0".into(),
             PhysicalProperties {
                 // "physical" size, not virtual
@@ -29,39 +25,30 @@ impl WLCOutput {
                 make: "Virtual".into(),
                 model: "Monitor".into(),
                 serial_number: "V1RT".into(),
-            }
+            },
         );
-        output.set_preferred(output::Mode {
-            size: Size::new(1920, 1080),
-            refresh: 60000,
-        });
-        WLCOutput {
-            output,
-            bounds: Size::new(1920, 1080),
-            display_handle: display_handle.clone(),
-        }
-    }
-
-    pub fn create_global(&self) {
-        self.display_handle
-            .create_global::<WLCState, WlOutput, ()>(4, ());
+        let output = WLCOutput { inner, bounds };
+        output.resize(bounds.w, bounds.h);
+        output
     }
 
     pub fn size(&self) -> Size<i32, Logical> {
-        self.output.preferred_mode().unwrap().size.to_logical(1)
+        self.inner.preferred_mode().unwrap().size.to_logical(1)
     }
 
     pub fn bounds(&self) -> Size<i32, Logical> {
         self.bounds
     }
 
-    pub fn resize(&mut self, width: i32, height: i32) {
-        let old_preferred = self.output.preferred_mode().unwrap();
-        self.output.set_preferred(output::Mode {
+    pub fn resize(&self, width: i32, height: i32) {
+        let old_preferred = self.inner.preferred_mode();
+        self.inner.set_preferred(output::Mode {
             size: Size::new(width, height),
-            refresh: 60000,
+            refresh: 0,
         });
-        self.output.delete_mode(old_preferred);
+        if let Some(old) = old_preferred {
+            self.inner.delete_mode(old);
+        }
     }
 
     pub fn set_bounds(&mut self, width: i32, height: i32) {
@@ -69,63 +56,4 @@ impl WLCOutput {
     }
 }
 
-impl GlobalDispatch<WlOutput, ()> for WLCState {
-    fn bind(
-        state: &mut Self,
-        _handle: &DisplayHandle,
-        _client: &Client,
-        resource: New<WlOutput>,
-        _data: &(),
-        data_init: &mut DataInit<'_, Self>,
-    ) {
-        let output: WlOutput = data_init.init(resource, ());
-        let state_output = &state.output.output;
-
-        let flags = wl_output::Mode::Current;
-        if let Some(mode) = state_output.current_mode() {
-            output.mode(flags, mode.size.w, mode.size.h, mode.refresh);
-        }
-
-        let location = state_output.current_location();
-        let physical = state_output.physical_properties();
-        output.geometry(
-            location.x,
-            location.y,
-            physical.size.w,
-            physical.size.h,
-            wl_output::Subpixel::None,
-            //physical.subpixel,
-            physical.make,
-            physical.model,
-            wl_output::Transform::Normal
-            //state_output.current_transform()
-        );
-
-        if output.version() >= 4 {
-            output.name(state_output.name());
-            output.description(state_output.description());
-        }
-
-        if output.version() >= 2 {
-            output.scale(1);
-            output.done();
-        }
-    }
-}
-
-impl Dispatch<WlOutput, ()> for WLCState {
-    fn request(
-        _state: &mut Self,
-        _client: &Client,
-        _output: &WlOutput,
-        request: wl_output::Request,
-        _data: &(),
-        _disp: &DisplayHandle,
-        _data_init: &mut DataInit<'_, Self>,
-    ) {
-        match request {
-            wl_output::Request::Release => {}
-            _ => unreachable!(),
-        }
-    }
-}
+impl OutputHandler for WLCState {}

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.stream.Stream;
 
+import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
@@ -147,6 +148,10 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		if(bridge == null) return;
 		
 		displays.forEach((d) -> d.render(ctx));
+
+		long presentationTime = Util.getNanos();
+		int refreshRate = Minecraft.getInstance().getWindow().getRefreshRate();
+		bridge.framePresented(presentationTime, refreshRate);
 	}
 	
 	public void updateWorld(LevelExtractionContext ctx) {

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.stream.Stream;
 
-import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
@@ -148,10 +147,6 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		if(bridge == null) return;
 		
 		displays.forEach((d) -> d.render(ctx));
-
-		long presentationTime = Util.getNanos();
-		int refreshRate = Minecraft.getInstance().getWindow().getRefreshRate();
-		bridge.framePresented(presentationTime, refreshRate);
 	}
 	
 	public void updateWorld(LevelExtractionContext ctx) {

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WLCSurface.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WLCSurface.java
@@ -151,6 +151,8 @@ public class WLCSurface {
 	}
 	
 	protected void addBufferDamage(int x, int y, int width, int height) {
+		if(buffer == null) return;
+
 		double sx = x;
 		double sy = y;
 		double sw = width;

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -393,6 +393,10 @@ public class WaylandCraftBridge {
 		
 		profiler.pop();
 	}
+
+	public void framePresented(long presentationTime, int refreshRate) {
+		sendPresentation(instance, presentationTime, refreshRate);
+	}
 	
 	private void updateFramebuffers() {
 		List<WLCAbstractWindow> allWindows = Stream.of(toplevels, popups).flatMap((l) -> l.stream()).collect(Collectors.toList());
@@ -681,6 +685,7 @@ public class WaylandCraftBridge {
 	private static native void update(long instance);
 	private static native String socket(long instance);
 	private static native void sendFrame(long surfaceHandle);
+	private static native void sendPresentation(long instance, long presentationTime, int refreshRate);
 	
 	private static native void updateSurfaceData(long instance, WLCSurface surface);
 	

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -45,6 +45,9 @@ public class WaylandCraftBridge {
 	private @Nullable Integer lastMoveRequestSerial = null;
 	private @Nullable ResizeRequest lastResizeRequest = null;
 	
+	private float smoothedRefresh = 60.0f;
+	private static final float ALPHA = 0.05f;
+	
 	static {
 		boolean loaded = false;
 		InputStream inputStream = openNativeLibraryFromJar();
@@ -264,8 +267,10 @@ public class WaylandCraftBridge {
 		profiler.push("wayland");
 
 		long presentationTime = Util.getNanos();
-		int refreshRate = Minecraft.getInstance().getWindow().getRefreshRate();
-		sendPresentation(instance, presentationTime, refreshRate);
+		int refreshRate = Minecraft.getInstance().getFps();
+		if(refreshRate <= 0) refreshRate = 60;
+		smoothedRefresh = smoothedRefresh * (1 - ALPHA) + refreshRate * ALPHA;
+		sendPresentation(instance, presentationTime, Math.round(smoothedRefresh));
 		
 		// Update wayland clients
 		profiler.push("update");

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -404,10 +404,6 @@ public class WaylandCraftBridge {
 		
 		profiler.pop();
 	}
-
-	public void framePresented(long presentationTime, int refreshRate) {
-		sendPresentation(instance, presentationTime, refreshRate);
-	}
 	
 	private void updateFramebuffers() {
 		List<WLCAbstractWindow> allWindows = Stream.of(toplevels, popups).flatMap((l) -> l.stream()).collect(Collectors.toList());

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -22,6 +22,8 @@ import dev.evvie.waylandcraft.bridge.WLCAbstractWindow.SurfaceGeometry;
 import dev.evvie.waylandcraft.desktop.RawDesktopEntry;
 import dev.evvie.waylandcraft.render.BufferTexture.DmabufTexture;
 import dev.evvie.waylandcraft.render.WindowFramebuffer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.Util;
 import net.minecraft.util.profiling.Profiler;
 import net.minecraft.util.profiling.ProfilerFiller;
 
@@ -260,6 +262,10 @@ public class WaylandCraftBridge {
 	public void update() {
 		ProfilerFiller profiler = Profiler.get();
 		profiler.push("wayland");
+
+		long presentationTime = Util.getNanos();
+		int refreshRate = Minecraft.getInstance().getWindow().getRefreshRate();
+		sendPresentation(instance, presentationTime, refreshRate);
 		
 		// Update wayland clients
 		profiler.push("update");


### PR DESCRIPTION
Originally I wanted to fix Chromium flickering as they used this protocol. However, they switched to wp_linux_drm_syncobj_v1.

Anyways, this protocol can be required for some applications like Gamescope. I tested gamescope, it feels better than xwayland-satellite.