### PR TITLE
Fix incorrect dmabuf access

### DIFF
--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -12,7 +12,7 @@ use jni::{
     sys::{jboolean, jbyte, jdouble, jint, jlong},
 };
 use smithay::{
-    backend::allocator::{Buffer, dmabuf::Dmabuf},
+    backend::allocator::{Buffer, dmabuf::WeakDmabuf},
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel,
         wayland_server::{
@@ -52,7 +52,7 @@ pub(crate) struct BridgeState {
     toplevels: Vec<Box<ToplevelSurface>>,
     popups: Vec<Box<PopupSurface>>,
     surfaces: Vec<Box<WlSurface>>,
-    dmabufs: Vec<Box<Dmabuf>>,
+    dmabufs: Vec<Box<WeakDmabuf>>,
 }
 
 impl BridgeState {
@@ -209,9 +209,9 @@ bind_java_type! {
             name = "surfaceXDGGeometry",
             fn = surface_xdg_geometry,
         },
-        static extern fn delete_dmabuf {
-            sig = (instance: jlong, dmabuf_handle: jlong),
-            fn = delete_dmabuf
+        static extern fn dmabufs {
+            sig = (instance: jlong) -> jlong[],
+            fn = dmabufs
         },
         extern fn update_surface_tree {
             sig = (instance: jlong, surface: WLCSurface) -> WLCSurface,
@@ -795,9 +795,8 @@ fn try_attach_dmabuf(
     let height = dmabuf.height() as jint;
     ensure_viewport_valid(surf_data, Size::new(width, height));
 
-    // This insert clones the dmabuf reference counter and as such ensures
-    // that a strong reference to the dmabuf is kept.
-    let handle = insert_get_handle(&mut instance.bridge.dmabufs, dmabuf);
+    let weak = dmabuf.weak();
+    let handle = insert_get_handle(&mut instance.bridge.dmabufs, &weak);
 
     let already_attached = jsurface.attach_dmabuf(env, handle).unwrap();
 
@@ -817,20 +816,18 @@ fn try_attach_dmabuf(
     BufferAttachResult::Success
 }
 
-fn delete_dmabuf<'local>(
-    _env: &mut Env<'local>,
+fn dmabufs<'local>(
+    env: &mut Env<'local>,
     _class: JClass<'local>,
     instance: jlong,
-    dmabuf_handle: jlong,
-) -> Result<(), BridgeError> {
-    let instance = jptr_to_instance!(instance, "deleteDmabuf")?;
-    let dmabuf = jptr_to_ref::<Dmabuf>(dmabuf_handle).ok_or_else(|| {
-        BridgeError::Null("deleteDmabuf: dmabufHandle is null")
-    })?;
+) -> Result<JPrimitiveArray<'local, jlong>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "dmabufs")?;
+    instance.bridge.dmabufs.retain(|d| !d.is_gone());
 
-    instance.bridge.dmabufs.retain(|d| **d != *dmabuf);
-
-    Ok(())
+    let handles = get_all_handles(&mut instance.bridge.dmabufs);
+    let array = JLongArray::new(env, handles.len())?;
+    array.set_region(env, 0, &handles)?;
+    Ok(array)
 }
 
 // Proxy to call the try_attach_* family of functions
@@ -897,6 +894,9 @@ fn update_surface_data<'local>(
             }
 
             // Done with buffer attachment
+            // All buffers are immediately released because at this point they
+            // are all already written to an independent OpenGL texture.
+            // (including the dmabufs)
             buf.release();
             attr.buffer = None;
         }

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WLCSurface.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WLCSurface.java
@@ -104,6 +104,9 @@ public class WLCSurface {
 		if(this.buffer != null) {
 			this.width = buffer.width;
 			this.height = buffer.height;
+			
+			DmabufTexture dmabuf = (DmabufTexture) this.buffer;
+			dmabuf.copyData();
 		}
 		return this.buffer != null;
 	}

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -199,6 +199,32 @@ public class WaylandCraftBridge {
 		this.popups = popups_new;
 	}
 	
+	private void updateDmabufs() {
+		long[] remainingHandles = dmabufs(instance);
+		ArrayList<DmabufTexture> dmabufs_new = new ArrayList<DmabufTexture>();
+		for(DmabufTexture dmabuf : this.dmabufs) {
+			// If the dmabuf texture is not attached to a real wl_buffer anymore, free the EGL resources
+			boolean retained = ArrayUtils.contains(remainingHandles, dmabuf.handle);
+			if(!retained) dmabuf.freeEGL();
+			
+			// Remove it from the list and free the texture if no longer attached to any surface
+			boolean used = false;
+			for(WLCSurface surface : surfaces) {
+				if(surface.getBuffer() == dmabuf) {
+					used = true;
+					break;
+				}
+			}
+			if(retained || used) {
+				dmabufs_new.add(dmabuf);
+			}
+			else {
+				dmabuf.doReleaseTexure();
+			}
+		}
+		this.dmabufs = dmabufs_new;
+	}
+	
 	private void deleteUnvisitedSurfaces() {
 		ArrayList<WLCSurface> surfaces_new = new ArrayList<WLCSurface>();
 		for(WLCSurface surface : this.surfaces) {
@@ -235,8 +261,8 @@ public class WaylandCraftBridge {
 		ProfilerFiller profiler = Profiler.get();
 		profiler.push("wayland");
 		
-		profiler.push("update");
 		// Update wayland clients
+		profiler.push("update");
 		update(this.instance);
 		profiler.pop();
 		
@@ -356,7 +382,7 @@ public class WaylandCraftBridge {
 		updateFramebuffers();
 		profiler.pop();
 		
-		freeUnusedDmabufs();
+		updateDmabufs();
 		
 		updateFocusOrder();
 		
@@ -366,25 +392,6 @@ public class WaylandCraftBridge {
 		}
 		
 		profiler.pop();
-	}
-	
-	private void freeUnusedDmabufs() {
-		ArrayList<DmabufTexture> unusedDmabufs = new ArrayList<>();
-		for(DmabufTexture dmabuf : dmabufs) {
-			boolean used = false;
-			for(WLCSurface surface : surfaces) {
-				if(surface.getBuffer() == dmabuf) {
-					used = true;
-					break;
-				}
-			}
-			if(!used) unusedDmabufs.add(dmabuf);
-		}
-		dmabufs.removeAll(unusedDmabufs);
-		for(DmabufTexture dmabuf : unusedDmabufs) {
-			dmabuf.free();
-			deleteDmabuf(instance, dmabuf.handle);
-		}
 	}
 	
 	private void updateFramebuffers() {
@@ -722,8 +729,7 @@ public class WaylandCraftBridge {
 	// Returns four-element array containing x,y,width,height which could be null
 	private static native int[] surfaceXDGGeometry(long surfaceHandle);
 	
-	// Release a dmabuf wl_buffer
-	private static native void deleteDmabuf(long instance, long dmabufHandle);
+	private static native long[] dmabufs(long instance);
 	
 	// Updates the surface tree given by the root surface
 	// This changes the doubly linked list of the WLCSurfaces.

--- a/src/main/java/dev/evvie/waylandcraft/render/BufferTexture.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/BufferTexture.java
@@ -1,6 +1,7 @@
 package dev.evvie.waylandcraft.render;
 
 import java.nio.ByteBuffer;
+import java.util.OptionalInt;
 
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWNativeEGL;
@@ -9,39 +10,71 @@ import org.lwjgl.system.JNI;
 
 import com.mojang.blaze3d.opengl.GlStateManager;
 import com.mojang.blaze3d.opengl.GlTexture;
+import com.mojang.blaze3d.pipeline.BlendFunction;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.pipeline.TextureTarget;
+import com.mojang.blaze3d.platform.DestFactor;
+import com.mojang.blaze3d.platform.SourceFactor;
+import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.textures.TextureFormat;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
 
+import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.mixin.IGlTextureMixin;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.resources.Identifier;
 
 public abstract class BufferTexture {
 	
 	public static final int FORMAT_ARGB8888 = 0;
 	public static final int FORMAT_XRGB8888 = 1;
 	
-	public final int id;
 	public final int width;
 	public final int height;
 	public final int format;
-	public GpuTextureView textureView;
 	
 	public BufferTexture(int width, int height, int format) {
 		this.width = width;
 		this.height = height;
 		this.format = format;
-		this.id = GlStateManager._genTexture();
-		GlTexture glTexture = IGlTextureMixin.createTexture(GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_TEXTURE_BINDING, "buffertexture-" + this.hashCode(), TextureFormat.RGBA8, width, height, 1, 1, id);
-		this.textureView = RenderSystem.getDevice().createTextureView(glTexture);
 	}
 	
-	public void release() {
-		GlStateManager._deleteTexture(id);
-		textureView = null;
+	public abstract GpuTextureView getTextureView();
+	public abstract void release();
+	
+	public static abstract class BasicBufferTexture extends BufferTexture {
+		
+		public final int id;
+		private GpuTextureView textureView = null;
+		
+		public BasicBufferTexture(int width, int height, int format) {
+			super(width, height, format);
+			this.id = GlStateManager._genTexture();
+			GlTexture glTexture = IGlTextureMixin.createTexture(GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_TEXTURE_BINDING, "buffertexture-" + this.hashCode(), TextureFormat.RGBA8, width, height, 1, 1, id);
+			this.textureView = RenderSystem.getDevice().createTextureView(glTexture);
+		}
+		
+		@Override
+		public GpuTextureView getTextureView() {
+			return textureView;
+		}
+		
+		@Override
+		public void release() {
+			textureView = null;
+			GlStateManager._deleteTexture(id);
+		}
+		
 	}
 	
-	public static class ShmBufferTexture extends BufferTexture {
+	public static class ShmBufferTexture extends BasicBufferTexture {
 		
 		private final long ptr;
 		private final int stride;
@@ -74,7 +107,7 @@ public abstract class BufferTexture {
 		
 	}
 	
-	public static class SinglePixelBufferTexture extends BufferTexture {
+	public static class SinglePixelBufferTexture extends BasicBufferTexture {
 		
 		public final byte r;
 		public final byte g;
@@ -116,20 +149,47 @@ public abstract class BufferTexture {
 		
 	}
 	
+	public static final RenderPipeline DMABUF_BLIT = RenderPipelines.register(
+		RenderPipeline.builder()
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/dmabuf_blit"))
+			.withVertexShader("core/screenquad")
+			.withFragmentShader("core/blit_screen")
+			.withSampler("InSampler")
+			.withColorTargetState(new ColorTargetState(new BlendFunction(SourceFactor.ONE, DestFactor.ONE_MINUS_SRC_ALPHA)))
+			.withVertexFormat(DefaultVertexFormat.EMPTY, VertexFormat.Mode.TRIANGLES)
+			.build()
+	);
+	
 	public static class DmabufTexture extends BufferTexture {
 		
 		public final long handle;
 		private final long eglImage;
 		
+		private GpuTextureView eglImageView = null;
+		private int eglImageTex = -1;
+		
+		private RenderTarget target;
+		
 		public DmabufTexture(long handle, long eglImage, int width, int height) {
 			super(width, height, BufferTexture.FORMAT_ARGB8888);
 			this.handle = handle;
 			this.eglImage = eglImage;
+			
+			target = new TextureTarget("dmabuf-target-" + this.hashCode(), width, height, false);
+			
 			init();
 		}
 		
+		@Override
+		public GpuTextureView getTextureView() {
+			if(target == null) return null;
+			return target.getColorTextureView();
+		}
+		
 		private void init() {
-			GlStateManager._bindTexture(this.id);
+			/* Create texture for EGLImage */
+			eglImageTex = GlStateManager._genTexture();
+			GlStateManager._bindTexture(eglImageTex);
 			GlStateManager._texParameter(GL33.GL_TEXTURE_2D, GL33.GL_TEXTURE_MAX_LEVEL, 0);
 			GlStateManager._texParameter(GL33.GL_TEXTURE_2D, GL33.GL_TEXTURE_MIN_LOD, 0);
 			GlStateManager._texParameter(GL33.GL_TEXTURE_2D, GL33.GL_TEXTURE_MAX_LOD, 0);
@@ -139,6 +199,22 @@ public abstract class BufferTexture {
 			
 			long glEGLImageTargetTexture2DOES = GLFW.glfwGetProcAddress("glEGLImageTargetTexture2DOES");
 			JNI.invokeJV(GL33.GL_TEXTURE_2D, this.eglImage, glEGLImageTargetTexture2DOES);
+			
+			GlTexture glTexture = IGlTextureMixin.createTexture(GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_TEXTURE_BINDING, "eglimage-" + this.hashCode(), TextureFormat.RGBA8, width, height, 1, 1, eglImageTex);
+			eglImageView = RenderSystem.getDevice().createTextureView(glTexture);
+			
+			copyData();
+		}
+		
+		public void copyData() {
+			if(eglImageView == null) return;
+			
+			try (RenderPass renderPass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "Dmabuf blit", target.getColorTextureView(), OptionalInt.of(0x00000000))) {
+				renderPass.setPipeline(DMABUF_BLIT);
+				RenderSystem.bindDefaultUniforms(renderPass);
+				renderPass.bindTexture("InSampler", eglImageView, RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+				renderPass.draw(0, 3);
+			}
 		}
 		
 		@Override
@@ -146,13 +222,20 @@ public abstract class BufferTexture {
 			// Don't release texture id as dmabuf textures might get reused
 		}
 		
-		public void free() {
-			super.release();
+		public void doReleaseTexure() {
+			target.destroyBuffers();
+			target = null;
+		}
+		
+		public void freeEGL() {
+			if(eglImageView == null) return;
 			
-			long eglDestroyImage = GLFW.glfwGetProcAddress("eglDestroyImage");
 			long display = GLFWNativeEGL.glfwGetEGLDisplay();
-			
+			long eglDestroyImage = GLFW.glfwGetProcAddress("eglDestroyImage");
 			JNI.invokePPI(display, this.eglImage, eglDestroyImage);
+			
+			GlStateManager._deleteTexture(eglImageTex);
+			eglImageView = null;
 		}
 		
 	}

--- a/src/main/java/dev/evvie/waylandcraft/render/WindowFramebuffer.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/WindowFramebuffer.java
@@ -227,7 +227,7 @@ public class WindowFramebuffer {
 			crop_y2 = (float) ((src.y() + src.height()) / buf.height);
 		}
 		
-		return new BufferDraw(buf.textureView, x, y, w, h, crop_x1, crop_y1, crop_x2, crop_y2, buf.format != BufferTexture.FORMAT_XRGB8888);
+		return new BufferDraw(buf.getTextureView(), x, y, w, h, crop_x1, crop_y1, crop_x2, crop_y2, buf.format != BufferTexture.FORMAT_XRGB8888);
 	}
 	
 	private static record CompiledBufferDraw(GpuTextureView textureView, GpuBuffer vertexBuffer, GpuBuffer indexBuffer, int indexCount, VertexFormat.IndexType indexType, boolean alpha) {


### PR DESCRIPTION
Dmabufs are now copied to a separate texture when attached to a surface.
This ensures that they are only read from the moment they are attached
to a surface and committed. Additionally this makes it so the buffers
can immediately be released like the other types of wl_buffer because
their pixels are saved to an independent OpenGL texture. Due to this,
dmabufs only need to be kept as weak references again. This commit
should hopefully quell the cyberpsychosis crisis for good.