### PR TITLE
Support for items on servers

### DIFF
--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -36,6 +36,7 @@ import dev.evvie.waylandcraft.render.WindowInItemFrameRenderer;
 import dev.evvie.waylandcraft.render.model.WindowItemModel;
 import dev.evvie.waylandcraft.settings.WaylandCraftSettings;
 import dev.evvie.waylandcraft.settings.WaylandCraftSettingsManager;
+import dev.evvie.waylandcraft.utils.CursorShape;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -119,6 +119,7 @@ public class WaylandCraft implements ClientModInitializer {
 		ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
 		ClientPlayConnectionEvents.JOIN.register(this::onClientJoin);
 		ItemTooltipCallback.EVENT.register(this::addWindowItemTooltip);
+		ClientTickEvents.START_CLIENT_TICK.register(itemManager);
 		
 		WaylandCraftCommon.instance.windowItemInteractionProvider = itemManager;
 		

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -2,6 +2,7 @@ package dev.evvie.waylandcraft;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
@@ -37,13 +38,14 @@ import dev.evvie.waylandcraft.settings.WaylandCraftSettingsManager;
 import dev.evvie.waylandcraft.utils.CursorShape;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelExtractionContext;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Camera;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
@@ -51,7 +53,9 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
@@ -74,7 +78,7 @@ public class WaylandCraft implements ClientModInitializer {
 	
 	public WLCToplevel pinnedToplevel = null;
 	
-	public WindowItemManager itemManager = new WindowItemManager(this);
+	public WindowItemManager itemManager = new WindowItemManager();
 	public XDGDesktopManager xdgManager;
 	
 	public KeyMapping keyOpenScreen;
@@ -113,8 +117,10 @@ public class WaylandCraft implements ClientModInitializer {
 		LevelRenderEvents.COLLECT_SUBMITS.register(this::renderWorld);
 		LevelRenderEvents.END_EXTRACTION.register(this::updateWorld);
 		ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
-		ServerTickEvents.START_LEVEL_TICK.register(itemManager::onServerTick);
 		ClientPlayConnectionEvents.JOIN.register(this::onClientJoin);
+		ItemTooltipCallback.EVENT.register(this::addWindowItemTooltip);
+		
+		WaylandCraftCommon.instance.windowItemInteractionProvider = itemManager;
 		
 		WindowItemModel.register();
 		hudRenderer.register();
@@ -187,7 +193,7 @@ public class WaylandCraft implements ClientModInitializer {
 		if(playerUsingWindowItem) {
 			ItemStack item = Minecraft.getInstance().player.getUseItem();
 			if(item.is(WindowItem.WINDOW)) {
-				WLCToplevel toplevel = WindowItem.getToplevel(item);
+				WLCToplevel toplevel = getToplevel(item);
 				
 				if(toplevel != null) {
 					WindowDisplay display = getOrCreateDisplay(toplevel);
@@ -250,6 +256,28 @@ public class WaylandCraft implements ClientModInitializer {
 	private void onClientJoin(ClientPacketListener listener, PacketSender sender, Minecraft minecraft) {
 		minecraft.getChatListener().handleSystemMessage(Component.literal("Wayland compositor running on " + waylandSocket), false);
 		itemManager.giveItemsIfMissing(bridge.getMappedToplevels());
+	}
+	
+	@Nullable
+	public static WLCToplevel getToplevel(ItemStack item) {
+		if(item == null) return null;
+		
+		Long data = item.get(WindowItem.WINDOW_HANDLE);
+		if(data == null) return null;
+		
+		long handle = data.longValue();
+		return WaylandCraft.instance.bridge.getToplevel(handle);
+	}
+	
+	private void addWindowItemTooltip(ItemStack itemStack, TooltipContext ctx, TooltipFlag flag, List<Component> list) {
+		Long handle = itemStack.get(WindowItem.WINDOW_HANDLE);
+		if(handle != null) {
+			String text = "Handle 0x" + Long.toHexString(handle.longValue());
+			Component component = Component
+					.literal(text)
+					.withStyle(ChatFormatting.GRAY);
+			list.add(component);
+		}
 	}
 	
 	private void updateDisplayRequests() {
@@ -549,7 +577,7 @@ public class WaylandCraft implements ClientModInitializer {
 	 */
 	public boolean onScroll(long windowHandle, double scrollX, double scrollY) {
 		if(playerUsingWindowItem) {
-			WLCToplevel toplevel = WindowItem.getToplevel(Minecraft.getInstance().player.getUseItem());
+			WLCToplevel toplevel = getToplevel(Minecraft.getInstance().player.getUseItem());
 			if(toplevel != null) {
 				WindowDisplay display = getDisplay(toplevel);
 				if(display != null) {

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -6,8 +6,6 @@ import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mojang.blaze3d.platform.InputConstants;
 
@@ -38,7 +36,6 @@ import dev.evvie.waylandcraft.settings.WaylandCraftSettings;
 import dev.evvie.waylandcraft.settings.WaylandCraftSettingsManager;
 import dev.evvie.waylandcraft.utils.CursorShape;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
@@ -58,10 +55,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
-public class WaylandCraft implements ModInitializer, ClientModInitializer {
-	public static final String MOD_ID = "waylandcraft";
-	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
-	private static final KeyMapping.Category KEYBIND_CATEGORY = KeyMapping.Category.register(Identifier.fromNamespaceAndPath(MOD_ID, "keys"));
+public class WaylandCraft implements ClientModInitializer {
+	
+	private static final KeyMapping.Category KEYBIND_CATEGORY = KeyMapping.Category.register(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "keys"));
 	
 	public static WaylandCraft instance;
 	
@@ -105,13 +101,8 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 	public @Nullable CursorShape cursorShape = null;
 	
 	@Override
-	public void onInitialize() {
-		WindowItem.register();
-	}
-	
-	@Override
 	public void onInitializeClient() {
-		LOGGER.info("Initializing WaylandCraft");
+		WaylandCraftCommon.LOGGER.info("Initializing WaylandCraft");
 		
 		instance = this;
 		
@@ -139,7 +130,7 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 			xdgManager = new XDGDesktopManager(this);
 			settingsManager = new WaylandCraftSettingsManager(this);
 			
-			LOGGER.info("Server started on " + waylandSocket);
+			WaylandCraftCommon.LOGGER.info("Server started on " + waylandSocket);
 		}
 		bridge.update();
 	}
@@ -336,13 +327,13 @@ public class WaylandCraft implements ModInitializer, ClientModInitializer {
 		if(dndRequest != null) {
 			ImplicitGrab implicit = pointerGrabs.dropImplicitMatching(dndRequest);
 			if(implicit != null) {
-				LOGGER.info("DND STARTED");
+				WaylandCraftCommon.LOGGER.info("DND STARTED");
 				// The serial matched an active implicit grab
 				pointerGrabs.startExclusive(new DNDGrab(implicit));
 			}
 			else {
 				// Couldn't match implicit grab, have to cancel dnd
-				LOGGER.info("drag and drop did not match implicit grab");
+				WaylandCraftCommon.LOGGER.info("drag and drop did not match implicit grab");
 				bridge.dndCancel();
 			}
 		}

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraftCommon.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraftCommon.java
@@ -4,9 +4,12 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.evvie.waylandcraft.item.ServerItemManager;
 import dev.evvie.waylandcraft.item.WindowItem;
 import dev.evvie.waylandcraft.item.WindowItemInteractionProvider;
+import dev.evvie.waylandcraft.network.WaylandCraftNetworking;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 
 public class WaylandCraftCommon implements ModInitializer {
 	
@@ -15,11 +18,15 @@ public class WaylandCraftCommon implements ModInitializer {
 	public static WaylandCraftCommon instance;
 	
 	public @Nullable WindowItemInteractionProvider windowItemInteractionProvider = null;
+	public ServerItemManager serverItemManager = new ServerItemManager();
 	
 	@Override
 	public void onInitialize() {
 		instance = this;
 		WindowItem.register();
+		WaylandCraftNetworking.register();
+		
+		ServerTickEvents.START_LEVEL_TICK.register(serverItemManager);
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraftCommon.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraftCommon.java
@@ -1,0 +1,21 @@
+package dev.evvie.waylandcraft;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.evvie.waylandcraft.item.WindowItem;
+import net.fabricmc.api.ModInitializer;
+
+public class WaylandCraftCommon implements ModInitializer {
+	
+	public static final String MOD_ID = "waylandcraft";
+	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+	public static WaylandCraftCommon instance;
+	
+	@Override
+	public void onInitialize() {
+		instance = this;
+		WindowItem.register();
+	}
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraftCommon.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraftCommon.java
@@ -1,9 +1,11 @@
 package dev.evvie.waylandcraft;
 
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dev.evvie.waylandcraft.item.WindowItem;
+import dev.evvie.waylandcraft.item.WindowItemInteractionProvider;
 import net.fabricmc.api.ModInitializer;
 
 public class WaylandCraftCommon implements ModInitializer {
@@ -11,6 +13,8 @@ public class WaylandCraftCommon implements ModInitializer {
 	public static final String MOD_ID = "waylandcraft";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 	public static WaylandCraftCommon instance;
+	
+	public @Nullable WindowItemInteractionProvider windowItemInteractionProvider = null;
 	
 	@Override
 	public void onInitialize() {

--- a/src/main/java/dev/evvie/waylandcraft/WindowDisplay.java
+++ b/src/main/java/dev/evvie/waylandcraft/WindowDisplay.java
@@ -11,6 +11,7 @@ import dev.evvie.waylandcraft.bridge.WLCSurface;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
 import dev.evvie.waylandcraft.math.WorldPlane;
 import dev.evvie.waylandcraft.render.RenderUtils;
+import dev.evvie.waylandcraft.utils.WaylandCraftUtils;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderContext;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -16,11 +16,11 @@ import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWNativeEGL;
 import org.lwjgl.system.Platform;
 
-import dev.evvie.waylandcraft.CursorShape;
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCAbstractWindow.SurfaceGeometry;
 import dev.evvie.waylandcraft.desktop.RawDesktopEntry;
 import dev.evvie.waylandcraft.render.BufferTexture.DmabufTexture;
+import dev.evvie.waylandcraft.utils.CursorShape;
 import dev.evvie.waylandcraft.render.WindowFramebuffer;
 import net.minecraft.util.profiling.Profiler;
 import net.minecraft.util.profiling.ProfilerFiller;

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -16,12 +16,12 @@ import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWNativeEGL;
 import org.lwjgl.system.Platform;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.bridge.WLCAbstractWindow.SurfaceGeometry;
 import dev.evvie.waylandcraft.desktop.RawDesktopEntry;
 import dev.evvie.waylandcraft.render.BufferTexture.DmabufTexture;
-import dev.evvie.waylandcraft.utils.CursorShape;
 import dev.evvie.waylandcraft.render.WindowFramebuffer;
+import dev.evvie.waylandcraft.utils.CursorShape;
 import net.minecraft.util.profiling.Profiler;
 import net.minecraft.util.profiling.ProfilerFiller;
 
@@ -61,20 +61,20 @@ public class WaylandCraftBridge {
 				System.load(temp.getAbsolutePath());
 				loaded = true;
 				
-				WaylandCraft.LOGGER.info("Loaded native library from jar");
+				WaylandCraftCommon.LOGGER.info("Loaded native library from jar");
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
 		}
 		
 		if(!loaded) {
-			WaylandCraft.LOGGER.info("Native library could not be loaded from jar. Attempting to load from system");
+			WaylandCraftCommon.LOGGER.info("Native library could not be loaded from jar. Attempting to load from system");
 			System.loadLibrary("waylandcraft");
 		}
 	}
 	
 	private static InputStream loadResource(String path) {
-		WaylandCraft.LOGGER.info("Looking for '" + path + "'...");
+		WaylandCraftCommon.LOGGER.info("Looking for '" + path + "'...");
 		return WaylandCraftBridge.class.getResourceAsStream(path);
 	}
 	

--- a/src/main/java/dev/evvie/waylandcraft/desktop/DesktopIcon.java
+++ b/src/main/java/dev/evvie/waylandcraft/desktop/DesktopIcon.java
@@ -14,6 +14,7 @@ import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.TextureFormat;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.mixin.NativeImageMixin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.AbstractTexture;
@@ -32,7 +33,7 @@ public class DesktopIcon {
 	
 	public DesktopIcon(String appId, String path) {
 		this.path = path;
-		this.identifier = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "icon_" + DigestUtils.sha1Hex(appId));
+		this.identifier = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "icon_" + DigestUtils.sha1Hex(appId));
 		this.wlc = WaylandCraft.instance;
 	}
 	

--- a/src/main/java/dev/evvie/waylandcraft/desktop/XDGDesktopManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/desktop/XDGDesktopManager.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 
 public class XDGDesktopManager {
 	
@@ -33,7 +34,7 @@ public class XDGDesktopManager {
 		}
 		this.systemEntries = systemEntries;
 		
-		WaylandCraft.LOGGER.info("Completed desktop entry loading in " + Duration.between(start, Instant.now()).toMillis() / 1000.0f + "s");
+		WaylandCraftCommon.LOGGER.info("Completed desktop entry loading in " + Duration.between(start, Instant.now()).toMillis() / 1000.0f + "s");
 		
 		Thread iconPreloadThread = new Thread(this::preloadIcons);
 		iconPreloadThread.start();
@@ -46,7 +47,7 @@ public class XDGDesktopManager {
 			entry.preloadIcon();
 		}
 		
-		WaylandCraft.LOGGER.info("Completed icon preloading in " + Duration.between(start, Instant.now()).toMillis() / 1000.0f + "s");
+		WaylandCraftCommon.LOGGER.info("Completed icon preloading in " + Duration.between(start, Instant.now()).toMillis() / 1000.0f + "s");
 	}
 	
 	private boolean completeFetch() {

--- a/src/main/java/dev/evvie/waylandcraft/grabs/MoveGrab.java
+++ b/src/main/java/dev/evvie/waylandcraft/grabs/MoveGrab.java
@@ -1,9 +1,9 @@
 package dev.evvie.waylandcraft.grabs;
 
-import dev.evvie.waylandcraft.CursorShape;
 import dev.evvie.waylandcraft.WindowDisplay;
 import dev.evvie.waylandcraft.WindowDisplay.DisplayHitResult;
 import dev.evvie.waylandcraft.grabs.PointerGrabMap.ImplicitGrab;
+import dev.evvie.waylandcraft.utils.CursorShape;
 import net.minecraft.world.phys.Vec3;
 
 public class MoveGrab extends PointerGrab {

--- a/src/main/java/dev/evvie/waylandcraft/gui/AppLauncherScreen.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/AppLauncherScreen.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.desktop.DesktopEntry;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.EditBox;
@@ -161,20 +162,20 @@ public class AppLauncherScreen extends Screen {
 	
 	private void createCategories() {
 		this.categories = new ArrayList<Category>();
-		categories.add(new Category("AudioVideo", Component.literal("Multimedia"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/multimedia"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Audio", Component.literal("Audio"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/music"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Video", Component.literal("Video"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/video"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Development", Component.literal("Development"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/development"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Education", Component.literal("Education"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/education"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("HealthFitness", Component.literal("Health and Fitness"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/healthfitness"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Game", Component.literal("Games"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/game"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Graphics", Component.literal("Graphics"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/graphics"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Network", Component.literal("Network"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/network"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Office", Component.literal("Office"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/office"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Science", Component.literal("Science"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/science"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Settings", Component.literal("Settings"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/settings"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("System", Component.literal("System"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/system"), new ArrayList<DesktopEntry>()));
-		categories.add(new Category("Utility", Component.literal("Utility"), Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "categories/utility"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("AudioVideo", Component.literal("Multimedia"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/multimedia"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Audio", Component.literal("Audio"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/music"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Video", Component.literal("Video"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/video"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Development", Component.literal("Development"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/development"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Education", Component.literal("Education"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/education"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("HealthFitness", Component.literal("Health and Fitness"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/healthfitness"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Game", Component.literal("Games"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/game"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Graphics", Component.literal("Graphics"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/graphics"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Network", Component.literal("Network"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/network"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Office", Component.literal("Office"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/office"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Science", Component.literal("Science"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/science"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Settings", Component.literal("Settings"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/settings"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("System", Component.literal("System"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/system"), new ArrayList<DesktopEntry>()));
+		categories.add(new Category("Utility", Component.literal("Utility"), Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "categories/utility"), new ArrayList<DesktopEntry>()));
 	}
 	
 	private static record RankedDesktopEntry(DesktopEntry entry, int score) {}

--- a/src/main/java/dev/evvie/waylandcraft/gui/AppWidget.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/AppWidget.java
@@ -3,7 +3,7 @@ package dev.evvie.waylandcraft.gui;
 import java.awt.Color;
 import java.util.function.Consumer;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.desktop.DesktopEntry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -20,8 +20,8 @@ import net.minecraft.util.ARGB;
 
 public class AppWidget extends AbstractWidget {
 	
-	private static final Identifier SLOT_THINGY = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "textures/gui/slot_thingy.png");
-	private static final Identifier SLOT_THINGY_SELECTED = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "textures/gui/slot_thingy_selected_overlay.png");
+	private static final Identifier SLOT_THINGY = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "textures/gui/slot_thingy.png");
+	private static final Identifier SLOT_THINGY_SELECTED = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "textures/gui/slot_thingy_selected_overlay.png");
 	
 	public final DesktopEntry entry;
 	private Consumer<DesktopEntry> launchAction;

--- a/src/main/java/dev/evvie/waylandcraft/gui/WaylandHudRenderer.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/WaylandHudRenderer.java
@@ -7,6 +7,7 @@ import org.joml.Matrix3x2fStack;
 
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.WaylandCraft.KeyboardCaptureMode;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.bridge.IconSurface;
 import dev.evvie.waylandcraft.bridge.WLCAbstractWindow.SurfaceGeometry;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
@@ -27,10 +28,10 @@ import net.minecraft.resources.Identifier;
 public class WaylandHudRenderer {
 	
 	private WaylandCraft wlc;
-	private static final Identifier TIME_DATE = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "time-date");
-	private static final Identifier APP_LIST = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "app-list");
-	private static final Identifier PINNED_TOPLEVEL = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pinned-toplevel");
-	private static final Identifier DND_ICON = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "dnd-icon");
+	private static final Identifier TIME_DATE = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "time-date");
+	private static final Identifier APP_LIST = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "app-list");
+	private static final Identifier PINNED_TOPLEVEL = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pinned-toplevel");
+	private static final Identifier DND_ICON = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "dnd-icon");
 	
 	public WaylandHudRenderer(WaylandCraft wlc) {
 		this.wlc = wlc;

--- a/src/main/java/dev/evvie/waylandcraft/gui/WindowManagerScreen.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/WindowManagerScreen.java
@@ -11,6 +11,7 @@ import org.joml.Matrix3x2fStack;
 import org.lwjgl.glfw.GLFW;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.bridge.WLCAbstractWindow;
 import dev.evvie.waylandcraft.bridge.WLCPopup;
 import dev.evvie.waylandcraft.bridge.WLCSurface;
@@ -130,11 +131,11 @@ public class WindowManagerScreen extends Screen {
 		
 		Component fullscreenComponent = Component.literal("Capture Mode").withColor(ARGB.color(255, 0, 0));
 		captureModeMessage = new StringWidget(leftMargin + 18, margin - 1, buttonWidth, buttonHeight, fullscreenComponent, font);
-		captureModeSprite = ImageWidget.sprite(15, 15, Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "capture"));
+		captureModeSprite = ImageWidget.sprite(15, 15, Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "capture"));
 		captureModeSprite.setPosition(leftMargin - 1, margin);
 		
 		hideButton = SpriteIconButton.builder(Component.literal("Hide"), this::onHidePressed, true)
-				.sprite(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "hide"), 15, 15)
+				.sprite(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "hide"), 15, 15)
 				.size(22, 22)
 				.build();
 		hideButton.setPosition(3, topMargin);
@@ -143,7 +144,7 @@ public class WindowManagerScreen extends Screen {
 		buttons.add(hideButton);
 		
 		pinButton = SpriteIconButton.builder(Component.literal("Pin"), this::onPinPressed, true)
-				.sprite(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pin"), 15, 15)
+				.sprite(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pin"), 15, 15)
 				.size(22, 22)
 				.build();
 		pinButton.setPosition(3, topMargin + 30);
@@ -152,7 +153,7 @@ public class WindowManagerScreen extends Screen {
 		buttons.add(pinButton);
 		
 		itemButton = SpriteIconButton.builder(Component.literal("Give Window Item"), this::onItemPressed, true)
-				.sprite(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window"), 16, 16)
+				.sprite(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"), 16, 16)
 				.size(22, 22)
 				.build();
 		itemButton.setPosition(3, topMargin + 60);
@@ -161,7 +162,7 @@ public class WindowManagerScreen extends Screen {
 		buttons.add(itemButton);
 		
 		helpButton = SpriteIconButton.builder(Component.literal("Help"), this::onHelpPressed, true)
-				.sprite(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "help"), 15, 15)
+				.sprite(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "help"), 15, 15)
 				.size(22, 22)
 				.build();
 		helpButton.setPosition(3, height - 22 - margin);

--- a/src/main/java/dev/evvie/waylandcraft/item/ServerItemManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/ServerItemManager.java
@@ -1,0 +1,102 @@
+package dev.evvie.waylandcraft.item;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import dev.evvie.waylandcraft.utils.IMyServerPlayer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+
+public class ServerItemManager implements ServerTickEvents.StartLevelTick {
+	
+	@Override
+	public void onStartTick(ServerLevel level) {
+		for(ServerPlayer player : level.players()) {
+			Inventory inv = player.getInventory();
+			for(int i = 0; i < inv.getContainerSize(); i++) {
+				ItemStack item = inv.getItem(i);
+				if(!item.is(WindowItem.WINDOW)) continue;
+				
+				Long handle = item.get(WindowItem.WINDOW_HANDLE);
+				if(!isHandleValid(level, handle)) {
+					inv.setItem(i, ItemStack.EMPTY);
+				}
+			}
+		}
+		
+		for(ServerPlayer player : level.players()) {
+			IMyServerPlayer plr = (IMyServerPlayer) player;
+			int itemGiveCooldown = plr.getItemGiveCooldown();
+			if(itemGiveCooldown > 0) {
+				plr.setItemGiveCooldown(itemGiveCooldown - 1);
+			}
+		}
+		
+		StreamSupport.stream(level.getAllEntities().spliterator(), false)
+			.filter((e) -> e instanceof ItemEntity)
+			.map((e) -> (ItemEntity) e)
+			.filter((e) -> e.getItem().is(WindowItem.WINDOW))
+			.filter((e) -> !isHandleValid(level, e.getItem().get(WindowItem.WINDOW_HANDLE)))
+			.filter((e) -> e.getAge() > 10)
+			.forEach((e) -> {
+				level.sendParticles(ParticleTypes.FLAME, false, false, e.getX(), e.getY(), e.getZ(), 10, 0.15, 0.2, 0.15, 0.1);
+				e.discard();
+			});
+	}
+	
+	private boolean isHandleValid(ServerLevel level, Long handle) {
+		if(handle == null) return false;
+		
+		for(ServerPlayer player : level.players()) {
+			IMyServerPlayer plr = (IMyServerPlayer) player;
+			if(plr.getAliveWindows().contains(handle)) return true;
+		}
+		
+		return false;
+	}
+	
+	public void giveItems(ServerPlayer player, List<Long> handles) {
+		for(Long handle : handles) giveItem(player, handle);
+	}
+	
+	public void giveItemsIfMissing(ServerPlayer player, List<Long> handles) {
+		for(Long handle : handles) giveItemIfMissing(player, handle);
+	}
+	
+	public void giveItem(ServerPlayer player, long handle) {
+		ItemStack item = createItem(handle);
+		player.addItem(item);
+	}
+	
+	public void giveItemIfMissing(ServerPlayer player, long handle) {
+		Inventory inv = player.getInventory();
+		
+		boolean foundToplevel = false;
+		for(int i = 0; i < inv.getContainerSize(); i++) {
+			ItemStack item = inv.getItem(i);
+			
+			if(!item.is(WindowItem.WINDOW)) continue;
+			if(item.get(WindowItem.WINDOW_HANDLE) == handle) {
+				foundToplevel = true;
+				break;
+			}
+		}
+		
+		if(!foundToplevel) {
+			ItemStack item = createItem(handle);
+			player.addItem(item);
+		}
+	}
+	
+	public static ItemStack createItem(long handle) {
+		ItemStack stack = new ItemStack(WindowItem.WINDOW, 1);
+		stack.set(WindowItem.WINDOW_HANDLE, handle);
+		return stack;
+	}
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItem.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItem.java
@@ -36,7 +36,6 @@ public class WindowItem extends Item {
 	public static Item WINDOW;
 	public static ResourceKey<Item> WINDOW_RESOURCE_KEY = ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"));
 	public static DataComponentType<Long> WINDOW_HANDLE;
-	public static Component BROKEN_WINDOW_TEXT = Component.literal("Broken Window");
 	public static Component UNKNOWN_WINDOW_TEXT = Component.literal("Unknown Window");
 	
 	public static void register() {
@@ -63,7 +62,7 @@ public class WindowItem extends Item {
 	@Override
 	public Component getName(ItemStack itemStack) {
 		WLCToplevel toplevel = getToplevel(itemStack);
-		if(toplevel == null) return BROKEN_WINDOW_TEXT;
+		if(toplevel == null) return UNKNOWN_WINDOW_TEXT;
 		
 		DesktopEntry entry = WaylandCraft.instance.xdgManager.forAppId(toplevel.appID);
 		if(entry == null) return UNKNOWN_WINDOW_TEXT;

--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItem.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItem.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import com.mojang.serialization.Codec;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
 import dev.evvie.waylandcraft.desktop.DesktopEntry;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
@@ -33,14 +34,14 @@ import net.minecraft.world.level.Level;
 public class WindowItem extends Item {
 	
 	public static Item WINDOW;
-	public static ResourceKey<Item> WINDOW_RESOURCE_KEY = ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window"));
+	public static ResourceKey<Item> WINDOW_RESOURCE_KEY = ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"));
 	public static DataComponentType<Long> WINDOW_HANDLE;
 	public static Component BROKEN_WINDOW_TEXT = Component.literal("Broken Window");
 	public static Component UNKNOWN_WINDOW_TEXT = Component.literal("Unknown Window");
 	
 	public static void register() {
 		WINDOW = Registry.register(BuiltInRegistries.ITEM, WINDOW_RESOURCE_KEY, new WindowItem());
-		WINDOW_HANDLE = Registry.register(BuiltInRegistries.DATA_COMPONENT_TYPE, Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window_handle"), DataComponentType.<Long>builder().persistent(Codec.LONG).build());
+		WINDOW_HANDLE = Registry.register(BuiltInRegistries.DATA_COMPONENT_TYPE, Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window_handle"), DataComponentType.<Long>builder().persistent(Codec.LONG).build());
 		ItemTooltipCallback.EVENT.register(WindowItem::addTooltip);
 	}
 	

--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItem.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItem.java
@@ -1,18 +1,8 @@
 package dev.evvie.waylandcraft.item;
 
-import java.util.List;
-
-import org.jetbrains.annotations.Nullable;
-
 import com.mojang.serialization.Codec;
 
-import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.WaylandCraftCommon;
-import dev.evvie.waylandcraft.bridge.WLCToplevel;
-import dev.evvie.waylandcraft.desktop.DesktopEntry;
-import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
-import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
@@ -27,7 +17,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.UseEffects;
 import net.minecraft.world.level.Level;
 
@@ -36,60 +25,30 @@ public class WindowItem extends Item {
 	public static Item WINDOW;
 	public static ResourceKey<Item> WINDOW_RESOURCE_KEY = ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"));
 	public static DataComponentType<Long> WINDOW_HANDLE;
-	public static Component UNKNOWN_WINDOW_TEXT = Component.literal("Unknown Window");
 	
 	public static void register() {
 		WINDOW = Registry.register(BuiltInRegistries.ITEM, WINDOW_RESOURCE_KEY, new WindowItem());
 		WINDOW_HANDLE = Registry.register(BuiltInRegistries.DATA_COMPONENT_TYPE, Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window_handle"), DataComponentType.<Long>builder().persistent(Codec.LONG).build());
-		ItemTooltipCallback.EVENT.register(WindowItem::addTooltip);
 	}
 	
 	public WindowItem() {
 		super(new Properties().setId(WINDOW_RESOURCE_KEY).component(DataComponents.USE_EFFECTS, new UseEffects(true, false, 1.0f)));
 	}
 	
-	@Nullable
-	public static WLCToplevel getToplevel(ItemStack item) {
-		if(item == null) return null;
-		
-		Long data = item.get(WINDOW_HANDLE);
-		if(data == null) return null;
-		
-		long handle = data.longValue();
-		return WaylandCraft.instance.bridge.getToplevel(handle);
-	}
-	
 	@Override
 	public Component getName(ItemStack itemStack) {
-		WLCToplevel toplevel = getToplevel(itemStack);
-		if(toplevel == null) return UNKNOWN_WINDOW_TEXT;
+		WindowItemInteractionProvider provider = WaylandCraftCommon.instance.windowItemInteractionProvider;
+		if(provider == null) return super.getName(itemStack);
 		
-		DesktopEntry entry = WaylandCraft.instance.xdgManager.forAppId(toplevel.appID);
-		if(entry == null) return UNKNOWN_WINDOW_TEXT;
-		
-		String name = entry.name;
-		if(name == null) return UNKNOWN_WINDOW_TEXT;
-		
-		return Component.literal(name);
-	}
-	
-	private static void addTooltip(ItemStack itemStack, TooltipContext ctx, TooltipFlag flag, List<Component> list) {
-		Long handle = itemStack.get(WINDOW_HANDLE);
-		if(handle != null) {
-			String text = "Handle 0x" + Long.toHexString(handle.longValue());
-			Component component = Component
-					.literal(text)
-					.withStyle(ChatFormatting.GRAY);
-			list.add(component);
-		}
+		return provider.getName(itemStack);
 	}
 	
 	@Override
 	public InteractionResult use(Level level, Player player, InteractionHand interactionHand) {
 		ItemStack item = player.getItemInHand(interactionHand);
-		WLCToplevel toplevel = getToplevel(item);
+		WindowItemInteractionProvider provider = WaylandCraftCommon.instance.windowItemInteractionProvider;
 		
-		if(toplevel == null) return InteractionResult.PASS;
+		if(provider != null && !provider.isValid(item)) return InteractionResult.PASS;
 		
 		player.startUsingItem(interactionHand);
 		return InteractionResult.CONSUME;
@@ -98,15 +57,11 @@ public class WindowItem extends Item {
 	@Override
 	public void onUseTick(Level level, LivingEntity livingEntity, ItemStack itemStack, int i) {
 		if(!level.isClientSide()) return;
-		if(livingEntity != Minecraft.getInstance().player) return;
 		
-		WaylandCraft.instance.startUsingWindowItem();
-	}
-	
-	public static ItemStack createItem(WLCToplevel toplevel) {
-		ItemStack stack = new ItemStack(WindowItem.WINDOW, 1);
-		stack.set(WINDOW_HANDLE, toplevel.getHandle());
-		return stack;
+		WindowItemInteractionProvider provider = WaylandCraftCommon.instance.windowItemInteractionProvider;
+		if(provider != null) {
+			provider.useTick(livingEntity, itemStack);
+		}
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItemInteractionProvider.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItemInteractionProvider.java
@@ -1,0 +1,24 @@
+package dev.evvie.waylandcraft.item;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+// Used as a proxy interface to client-only by WindowItem
+public interface WindowItemInteractionProvider {
+	
+	// Returns true when an ItemStack still holds a currently alive window
+	// The `itemStack` is guaranteed to be an instance of `WindowItem`.
+	boolean isValid(ItemStack itemStack);
+	
+	// Returns printable name for a window item
+	// The `itemStack` is guaranteed to be an instance of `WindowItem`.
+	@Nullable Component getName(ItemStack itemStack);
+	
+	// Called every tick while the window item is being used
+	// The `itemStack` is guaranteed to be an instance of `WindowItem`.
+	void useTick(LivingEntity entity, ItemStack itemStack);
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItemManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItemManager.java
@@ -1,23 +1,54 @@
 package dev.evvie.waylandcraft.item;
 
+import java.util.Arrays;
+
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
 import dev.evvie.waylandcraft.desktop.DesktopEntry;
+import dev.evvie.waylandcraft.network.ServerboundAliveWindowsPayload;
+import dev.evvie.waylandcraft.network.ServerboundGiveItemsPayload;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
-public class WindowItemManager implements WindowItemInteractionProvider {
+public class WindowItemManager implements WindowItemInteractionProvider, ClientTickEvents.StartTick {
 	
 	private static Component UNKNOWN_WINDOW_TEXT = Component.literal("Unknown Window");
 	
+	// Toplevel handles last sent to the server for synchronization
+	private long[] syncedToplevels = new long[0];
+	
 	public void giveItem(WLCToplevel toplevel) {
-		/* TODO */
+		ClientPlayNetworking.send(new ServerboundGiveItemsPayload(new long[] {toplevel.getHandle()}, false));
 	}
 	
 	public void giveItemsIfMissing(WLCToplevel... toplevels) {
-		/* TODO */
+		if(toplevels.length < 1) return;
+		
+		long[] handles = new long[toplevels.length];
+		for(int i = 0; i < toplevels.length; i++) handles[i] = toplevels[i].getHandle();
+		
+		syncToplevels();
+		ClientPlayNetworking.send(new ServerboundGiveItemsPayload(handles, true));
+	}
+	
+	@Override
+	public void onStartTick(Minecraft client) {
+		if(client.level == null) return;
+		if(WaylandCraft.instance.bridge == null) return;
+		
+		syncToplevels();
+	}
+	
+	public void syncToplevels() {
+		long[] handles = Arrays.stream(WaylandCraft.instance.bridge.getToplevels()).mapToLong((t) -> t.getHandle()).toArray();
+		if(Arrays.equals(handles, syncedToplevels)) return;
+		
+		ClientPlayNetworking.send(new ServerboundAliveWindowsPayload(handles));
+		syncedToplevels = handles;
 	}
 	
 	@Override

--- a/src/main/java/dev/evvie/waylandcraft/item/WindowItemManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/item/WindowItemManager.java
@@ -1,106 +1,49 @@
 package dev.evvie.waylandcraft.item;
 
-import java.util.LinkedHashSet;
-import java.util.stream.StreamSupport;
-
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
+import dev.evvie.waylandcraft.desktop.DesktopEntry;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
-public class WindowItemManager {
+public class WindowItemManager implements WindowItemInteractionProvider {
 	
-	private WaylandCraft wlc;
-	private LinkedHashSet<WLCToplevel> giveItems = new LinkedHashSet<WLCToplevel>();
-	private LinkedHashSet<WLCToplevel> giveIfMissingItems = new LinkedHashSet<WLCToplevel>();
-	
-	public WindowItemManager(WaylandCraft wlc) {
-		this.wlc = wlc;
-	}
+	private static Component UNKNOWN_WINDOW_TEXT = Component.literal("Unknown Window");
 	
 	public void giveItem(WLCToplevel toplevel) {
-		giveItems.add(toplevel);
-	}
-	
-	public void giveItemIfMissing(WLCToplevel toplevel) {
-		giveIfMissingItems.add(toplevel);
-	}
-	
-	public void giveItems(WLCToplevel... toplevels) {
-		for(int i = 0; i < toplevels.length; i++) giveItem(toplevels[i]);
+		/* TODO */
 	}
 	
 	public void giveItemsIfMissing(WLCToplevel... toplevels) {
-		for(int i = 0; i < toplevels.length; i++) giveItemIfMissing(toplevels[i]);
+		/* TODO */
 	}
 	
-	private boolean isToplevelValid(WLCToplevel toplevel) {
-		return toplevel != null && toplevel.isMapped();
+	@Override
+	public boolean isValid(ItemStack itemStack) {
+		WLCToplevel toplevel = WaylandCraft.getToplevel(itemStack);
+		return toplevel != null;
 	}
 	
-	public void onServerTick(ServerLevel level) {
-		if(wlc.bridge == null) return;
-		if(level.players().size() < 1) return;
+	@Override
+	public Component getName(ItemStack itemStack) {
+		WLCToplevel toplevel = WaylandCraft.getToplevel(itemStack);
+		if(toplevel == null) return UNKNOWN_WINDOW_TEXT;
 		
-		level.players().forEach(player -> {
-			Inventory inv = player.getInventory();
-			
-			giveItems.forEach(toplevel -> {
-				ItemStack item = WindowItem.createItem(toplevel);
-				player.addItem(item);
-			});
-			
-			giveIfMissingItems.forEach((toplevel) -> {
-				boolean foundToplevel = false;
-				for(int i = 0; i < inv.getContainerSize(); i++) {
-					ItemStack item = inv.getItem(i);
-					
-					if(!item.is(WindowItem.WINDOW)) continue;
-					if(WindowItem.getToplevel(item) == toplevel) {
-						foundToplevel = true;
-						break;
-					}
-				}
-				
-				if(!foundToplevel) {
-					ItemStack item = WindowItem.createItem(toplevel);
-					player.addItem(item);
-				}
-			});
-			
-			for(int i = 0; i < inv.getContainerSize(); i++) {
-				ItemStack item = inv.getItem(i);
-				if(!item.is(WindowItem.WINDOW)) continue;
-				
-				WLCToplevel toplevel = WindowItem.getToplevel(item);
-				if(toplevel == null) {
-					inv.setItem(i, ItemStack.EMPTY);
-				}
-			}
-		});
+		DesktopEntry entry = WaylandCraft.instance.xdgManager.forAppId(toplevel.appID);
+		if(entry == null) return UNKNOWN_WINDOW_TEXT;
 		
-		giveItems.clear();
-		giveIfMissingItems.clear();
+		String name = entry.name;
+		if(name == null) return UNKNOWN_WINDOW_TEXT;
 		
-		StreamSupport.stream(level.getAllEntities().spliterator(), false)
-				.filter((e) -> e instanceof ItemEntity)
-				.map((e) -> (ItemEntity) e)
-				.filter((e) -> e.getItem().is(WindowItem.WINDOW))
-				.filter((e) -> !isToplevelValid(WindowItem.getToplevel(e.getItem())))
-				.filter((e) -> e.getAge() > 10)
-				.forEach((e) -> {
-					for(int i = 0; i < 10; i++) {
-						double dx = ((level.getRandom().nextDouble() * 2) - 1) * 0.15;
-						double dy = level.getRandom().nextDouble() * 0.2;
-						double dz = ((level.getRandom().nextDouble() * 2) - 1) * 0.15;
-						if(Minecraft.getInstance().level != null) Minecraft.getInstance().level.addParticle(ParticleTypes.FLAME, e.getX(), e.getY(), e.getZ(), dx, dy, dz);
-					}
-					e.discard();
-				});
+		return Component.literal(name);
+	}
+	
+	@Override
+	public void useTick(LivingEntity entity, ItemStack itemStack) {
+		if(entity != Minecraft.getInstance().player) return;
+		WaylandCraft.instance.startUsingWindowItem();
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/mixin/GuiMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/GuiMixin.java
@@ -9,8 +9,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 
-import dev.evvie.waylandcraft.CursorShape;
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.utils.CursorShape;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphicsExtractor;

--- a/src/main/java/dev/evvie/waylandcraft/mixin/GuiMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/GuiMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.utils.CursorShape;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.Gui;
@@ -19,19 +20,19 @@ import net.minecraft.resources.Identifier;
 @Mixin(Gui.class)
 public class GuiMixin {
 	
-	private static final Identifier TLBR_DIAGONAL_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/tlbr_diagonal");
-	private static final Identifier TRBL_DIAGONAL_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/trbl_diagonal");
-	private static final Identifier LEFT_RIGHT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/left_right");
-	private static final Identifier TOP_BOTTOM_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/top_bottom");
+	private static final Identifier TLBR_DIAGONAL_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/tlbr_diagonal");
+	private static final Identifier TRBL_DIAGONAL_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/trbl_diagonal");
+	private static final Identifier LEFT_RIGHT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/left_right");
+	private static final Identifier TOP_BOTTOM_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/top_bottom");
 	
-	private static final Identifier HELP_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/help");
-	private static final Identifier MOVE_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/move");
-	private static final Identifier POINTER_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/pointer");
-	private static final Identifier TEXT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/text");
-	private static final Identifier VTEXT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/vtext");
-	private static final Identifier WAIT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/wait");
-	private static final Identifier ZOOM_IN_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/zoom_in");
-	private static final Identifier ZOOM_OUT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "crosshair/zoom_out");
+	private static final Identifier HELP_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/help");
+	private static final Identifier MOVE_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/move");
+	private static final Identifier POINTER_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/pointer");
+	private static final Identifier TEXT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/text");
+	private static final Identifier VTEXT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/vtext");
+	private static final Identifier WAIT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/wait");
+	private static final Identifier ZOOM_IN_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/zoom_in");
+	private static final Identifier ZOOM_OUT_CROSSHAIR = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "crosshair/zoom_out");
 	
 	@Redirect(method = "extractCrosshair", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;blitSprite(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIII)V", ordinal = 0))
 	public void crosshairBlitSprite(GuiGraphicsExtractor context, RenderPipeline pipeline, Identifier original, int x, int y, int width, int height) {

--- a/src/main/java/dev/evvie/waylandcraft/mixin/ItemFrameRendererMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/ItemFrameRendererMixin.java
@@ -11,7 +11,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
-import dev.evvie.waylandcraft.item.WindowItem;
 import dev.evvie.waylandcraft.render.IMyItemFrameRenderState;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
@@ -38,7 +37,7 @@ public class ItemFrameRendererMixin {
 	
 	@Inject(method = "extractRenderState", at = @At("HEAD"))
 	public void extractRenderState(ItemFrame itemFrame, ItemFrameRenderState itemFrameRenderState, float f, CallbackInfo info) {
-		WLCToplevel toplevel = WindowItem.getToplevel(itemFrame.getItem());
+		WLCToplevel toplevel = WaylandCraft.getToplevel(itemFrame.getItem());
 		((IMyItemFrameRenderState) itemFrameRenderState).setToplevel(toplevel);
 	}
 	

--- a/src/main/java/dev/evvie/waylandcraft/mixin/ItemInHandRendererMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/ItemInHandRendererMixin.java
@@ -37,7 +37,7 @@ public abstract class ItemInHandRendererMixin {
 		@Local LocalRef<HumanoidArm> humanoidArmRef
 	) {
 		if(!itemStack.is(WindowItem.WINDOW)) return;
-		if(WindowItem.getToplevel(itemStack) == null) return;
+		if(WaylandCraft.getToplevel(itemStack) == null) return;
 		
 		info.cancel();
 		

--- a/src/main/java/dev/evvie/waylandcraft/mixin/PauseScreenMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/PauseScreenMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.sugar.Local;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.gui.WaylandCraftSettingsScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.SpriteIconButton;
@@ -30,7 +31,7 @@ public class PauseScreenMixin extends Screen {
 	public void addButton(CallbackInfo info, @Local GridLayout layout) {
 		button = SpriteIconButton
 				.builder(Component.literal("waylandcraft"), (_) -> {Minecraft.getInstance().setScreen(new WaylandCraftSettingsScreen(WaylandCraft.instance));}, true)
-				.sprite(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "logo"), 16, 16)
+				.sprite(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "logo"), 16, 16)
 				.width(20)
 				.build();
 		layout.addChild(button, 3, 0);

--- a/src/main/java/dev/evvie/waylandcraft/mixin/ServerPlayerMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/ServerPlayerMixin.java
@@ -1,0 +1,31 @@
+package dev.evvie.waylandcraft.mixin;
+
+import java.util.ArrayList;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import dev.evvie.waylandcraft.utils.IMyServerPlayer;
+import net.minecraft.server.level.ServerPlayer;
+
+@Mixin(ServerPlayer.class)
+public class ServerPlayerMixin implements IMyServerPlayer {
+	
+	private int itemGiveCooldown = 0;
+	private ArrayList<Long> aliveWindows = new ArrayList<Long>();
+	
+	@Override
+	public int getItemGiveCooldown() {
+		return itemGiveCooldown;
+	}
+	
+	@Override
+	public void setItemGiveCooldown(int cooldown) {
+		itemGiveCooldown = cooldown;
+	}
+	
+	@Override
+	public ArrayList<Long> getAliveWindows() {
+		return aliveWindows;
+	}
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/mixin/TitleScreenMixin.java
+++ b/src/main/java/dev/evvie/waylandcraft/mixin/TitleScreenMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.sugar.Local;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.gui.WaylandCraftSettingsScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.SpriteIconButton;
@@ -27,7 +28,7 @@ public class TitleScreenMixin extends Screen {
 	public void addWaylandCraftButton(CallbackInfo info, @Local(ordinal = 3) int topPos) {
 		SpriteIconButton button = SpriteIconButton
 				.builder(Component.literal("waylandcraft"), (_) -> {Minecraft.getInstance().setScreen(new WaylandCraftSettingsScreen(WaylandCraft.instance));}, true)
-				.sprite(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "logo"), 16, 16)
+				.sprite(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "logo"), 16, 16)
 				.width(20)
 				.build();
 		button.setPosition(width / 2 - 124, topPos - 36);

--- a/src/main/java/dev/evvie/waylandcraft/network/ServerboundAliveWindowsPayload.java
+++ b/src/main/java/dev/evvie/waylandcraft/network/ServerboundAliveWindowsPayload.java
@@ -1,0 +1,23 @@
+package dev.evvie.waylandcraft.network;
+
+import dev.evvie.waylandcraft.WaylandCraftCommon;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+
+public record ServerboundAliveWindowsPayload(long[] handles) implements CustomPacketPayload {
+	
+	public static final Identifier ALIVE_WINDOWS_PAYLOAD_ID = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "alive_windows");
+	
+	public static final CustomPacketPayload.Type<ServerboundAliveWindowsPayload> TYPE = new CustomPacketPayload.Type<ServerboundAliveWindowsPayload>(ALIVE_WINDOWS_PAYLOAD_ID);
+	
+	public static final StreamCodec<RegistryFriendlyByteBuf, ServerboundAliveWindowsPayload> CODEC = StreamCodec.composite(ByteBufCodecs.LONG_ARRAY, ServerboundAliveWindowsPayload::handles, ServerboundAliveWindowsPayload::new);
+	
+	@Override
+	public Type<? extends CustomPacketPayload> type() {
+		return TYPE;
+	}
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/network/ServerboundGiveItemsPayload.java
+++ b/src/main/java/dev/evvie/waylandcraft/network/ServerboundGiveItemsPayload.java
@@ -1,0 +1,23 @@
+package dev.evvie.waylandcraft.network;
+
+import dev.evvie.waylandcraft.WaylandCraftCommon;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+
+public record ServerboundGiveItemsPayload(long[] handles, boolean missingOnly) implements CustomPacketPayload {
+	
+	public static final Identifier GIVE_ITEMS_PAYLOAD_ID = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "give_items");
+	
+	public static final CustomPacketPayload.Type<ServerboundGiveItemsPayload> TYPE = new CustomPacketPayload.Type<ServerboundGiveItemsPayload>(GIVE_ITEMS_PAYLOAD_ID);
+	
+	public static final StreamCodec<RegistryFriendlyByteBuf, ServerboundGiveItemsPayload> CODEC = StreamCodec.composite(ByteBufCodecs.LONG_ARRAY, ServerboundGiveItemsPayload::handles, ByteBufCodecs.BOOL, ServerboundGiveItemsPayload::missingOnly, ServerboundGiveItemsPayload::new);
+	
+	@Override
+	public Type<? extends CustomPacketPayload> type() {
+		return TYPE;
+	}
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/network/WaylandCraftNetworking.java
+++ b/src/main/java/dev/evvie/waylandcraft/network/WaylandCraftNetworking.java
@@ -1,0 +1,42 @@
+package dev.evvie.waylandcraft.network;
+
+import java.util.ArrayList;
+
+import dev.evvie.waylandcraft.WaylandCraftCommon;
+import dev.evvie.waylandcraft.utils.IMyServerPlayer;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+
+public class WaylandCraftNetworking {
+	
+	public static void register() {
+		PayloadTypeRegistry.serverboundPlay().register(ServerboundGiveItemsPayload.TYPE, ServerboundGiveItemsPayload.CODEC);
+		PayloadTypeRegistry.serverboundPlay().register(ServerboundAliveWindowsPayload.TYPE, ServerboundAliveWindowsPayload.CODEC);
+		
+		ServerPlayNetworking.registerGlobalReceiver(ServerboundGiveItemsPayload.TYPE, (payload, ctx) -> {
+			IMyServerPlayer plr = (IMyServerPlayer) ctx.player();
+			if(plr.getItemGiveCooldown() > 0) return;
+			plr.setItemGiveCooldown(10);
+			
+			ArrayList<Long> handles = new ArrayList<Long>();
+			for(long handle : payload.handles()) {
+				if(handles.contains(handle)) continue;
+				handles.add(handle);
+			}
+			
+			if(payload.missingOnly()) WaylandCraftCommon.instance.serverItemManager.giveItemsIfMissing(ctx.player(), handles);
+			else WaylandCraftCommon.instance.serverItemManager.giveItems(ctx.player(), handles);
+		});
+		
+		ServerPlayNetworking.registerGlobalReceiver(ServerboundAliveWindowsPayload.TYPE, (payload, ctx) -> {
+			IMyServerPlayer plr = (IMyServerPlayer) ctx.player();
+			ArrayList<Long> handles = plr.getAliveWindows();
+			handles.clear();
+			
+			for(long handle : payload.handles()) {
+				handles.add(handle);
+			}
+		});
+	}
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/render/BufferTexture.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/BufferTexture.java
@@ -26,7 +26,7 @@ import com.mojang.blaze3d.textures.TextureFormat;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.mixin.IGlTextureMixin;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
@@ -151,7 +151,7 @@ public abstract class BufferTexture {
 	
 	public static final RenderPipeline DMABUF_BLIT = RenderPipelines.register(
 		RenderPipeline.builder()
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/dmabuf_blit"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/dmabuf_blit"))
 			.withVertexShader("core/screenquad")
 			.withFragmentShader("core/blit_screen")
 			.withSampler("InSampler")

--- a/src/main/java/dev/evvie/waylandcraft/render/RenderUtils.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/RenderUtils.java
@@ -18,6 +18,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexFormat;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.mixin.IGuiGraphicsExtractor;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
@@ -32,43 +33,43 @@ import net.minecraft.world.phys.Vec3;
 public class RenderUtils {
 	
 	private static final RenderPipeline.Snippet WINDOW_PIPELINE_SNIPPET = RenderPipeline.builder(RenderPipelines.MATRICES_PROJECTION_SNIPPET)
-			.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/rendertype_window"))
-			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/rendertype_window"))
+			.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "core/rendertype_window"))
+			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "core/rendertype_window"))
 			.withSampler("Sampler0")
 			.withDepthStencilState(DepthStencilState.DEFAULT)
 			.withVertexFormat(DefaultVertexFormat.POSITION_TEX, VertexFormat.Mode.QUADS)
 			.buildSnippet();
 	
 	private static final RenderPipeline WINDOW_CUTOUT_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_cutout"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_cutout"))
 			.withShaderDefine("ALPHA_CUTOUT")
 			.build();
 	
 	private static final RenderPipeline WINDOW_TRANSLUCENT_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_translucent"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_translucent"))
 			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
 			.build();
 	
 	private static final RenderPipeline WINDOW_CUTOUT_ANTIALIASING_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_cutout"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_cutout"))
 			.withShaderDefine("ALPHA_CUTOUT")
 			.withShaderDefine("RGSS")
 			.build();
 	
 	private static final RenderPipeline WINDOW_TRANSLUCENT_ANTIALIASING_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_translucent"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_translucent"))
 			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
 			.withShaderDefine("RGSS")
 			.build();
 	
 	private static final RenderPipeline WINDOW_CUTOUT_BACKGROUND_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_cutout_background"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_cutout_background"))
 			.withShaderDefine("ALPHA_CUTOUT")
 			.withShaderDefine("NO_COLOR")
 			.build();
 	
 	private static final RenderPipeline WINDOW_TRANSLUCENT_BACKGROUND_PIPELINE = RenderPipeline.builder(WINDOW_PIPELINE_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_translucent_background"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_translucent_background"))
 			.withShaderDefine("NO_COLOR")
 			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
 			.build();
@@ -130,9 +131,9 @@ public class RenderUtils {
 	);
 	
 	public static final RenderPipeline WINDOW_BLIT = RenderPipeline.builder(RenderPipelines.MATRICES_PROJECTION_SNIPPET)
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window_blit"))
-			.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/window_blit"))
-			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/window_blit"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window_blit"))
+			.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "core/window_blit"))
+			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "core/window_blit"))
 			.withSampler("Sampler0")
 			.withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
 			.withVertexFormat(DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS)

--- a/src/main/java/dev/evvie/waylandcraft/render/WindowFramebuffer.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/WindowFramebuffer.java
@@ -29,7 +29,7 @@ import com.mojang.blaze3d.vertex.MeshData;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexFormat;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import dev.evvie.waylandcraft.bridge.WLCSurface;
 import dev.evvie.waylandcraft.bridge.WLCSurface.SurfaceDamage;
 import dev.evvie.waylandcraft.bridge.WLCSurface.ViewportSource;
@@ -46,9 +46,9 @@ public class WindowFramebuffer {
 	
 	public static final RenderPipeline WINDOW_PIPELINE = RenderPipelines.register(
 		RenderPipeline.builder()
-		.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/window"))
-		.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window"))
-		.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window"))
+		.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/window"))
+		.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"))
+		.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"))
 		.withVertexFormat(DefaultVertexFormat.POSITION_TEX, VertexFormat.Mode.QUADS)
 		.withSampler("sampler")
 		.withUniform("window_info", UniformType.UNIFORM_BUFFER)
@@ -59,9 +59,9 @@ public class WindowFramebuffer {
 	
 	public static final RenderPipeline DAMAGE_PIPELINE = RenderPipelines.register(
 		RenderPipeline.builder()
-		.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/damage"))
-		.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window"))
-		.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window_damage"))
+		.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/damage"))
+		.withVertexShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"))
+		.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window_damage"))
 		.withVertexFormat(DefaultVertexFormat.POSITION_TEX, VertexFormat.Mode.QUADS)
 		.withUniform("window_info", UniformType.UNIFORM_BUFFER)
 		.withCull(false)
@@ -259,7 +259,7 @@ public class WindowFramebuffer {
 		if(target == null) return;
 		
 		texture = new FramebufferTexture(getTextureView());
-		location = Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, name());
+		location = Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, name());
 		
 		Minecraft.getInstance().getTextureManager().register(location, texture);
 	}

--- a/src/main/java/dev/evvie/waylandcraft/render/WindowInHandRenderer.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/WindowInHandRenderer.java
@@ -6,7 +6,6 @@ import com.mojang.math.Axis;
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
 import dev.evvie.waylandcraft.bridge.WaylandCraftBridge.Size;
-import dev.evvie.waylandcraft.item.WindowItem;
 import dev.evvie.waylandcraft.mixin.IItemInHandRendererMixin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -47,7 +46,7 @@ public class WindowInHandRenderer {
 	}
 	
 	public void renderWindow(PoseStack poseStack, SubmitNodeCollector collector, float sideMult, int light, ItemStack itemStack) {
-		WLCToplevel toplevel = WindowItem.getToplevel(itemStack);
+		WLCToplevel toplevel = WaylandCraft.getToplevel(itemStack);
 		if(toplevel == null) return;
 		if(toplevel.framebuffer == null) return;
 		

--- a/src/main/java/dev/evvie/waylandcraft/render/WindowTranslucencyHotfix.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/WindowTranslucencyHotfix.java
@@ -10,7 +10,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
@@ -19,9 +19,9 @@ public class WindowTranslucencyHotfix {
 	
 	private static final RenderPipeline TRANSLUCENCY_HOTFIX_PIPELINE = RenderPipelines.register(
 			RenderPipeline.builder()
-			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "pipeline/translucency_hotfix"))
+			.withLocation(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "pipeline/translucency_hotfix"))
 			.withVertexShader("core/screenquad")
-			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "core/singlecolor"))
+			.withFragmentShader(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "core/singlecolor"))
 			.withColorTargetState(new ColorTargetState(Optional.empty(), ColorTargetState.WRITE_ALPHA))
 			.withVertexFormat(DefaultVertexFormat.EMPTY, VertexFormat.Mode.TRIANGLES)
 			.withShaderDefine("RED", 1.0f)

--- a/src/main/java/dev/evvie/waylandcraft/render/model/WindowItemModel.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/model/WindowItemModel.java
@@ -1,6 +1,6 @@
 package dev.evvie.waylandcraft.render.model;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import net.minecraft.client.renderer.item.properties.select.SelectItemModelProperties;
 import net.minecraft.client.renderer.special.SpecialModelRenderers;
 import net.minecraft.resources.Identifier;
@@ -8,8 +8,8 @@ import net.minecraft.resources.Identifier;
 public class WindowItemModel {
 	
 	public static void register() {
-		SelectItemModelProperties.ID_MAPPER.put(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window_state"), WindowStateProperty.TYPE);
-		SpecialModelRenderers.ID_MAPPER.put(Identifier.fromNamespaceAndPath(WaylandCraft.MOD_ID, "window"), WindowSpecialRenderer.Unbaked.MAP_CODEC);
+		SelectItemModelProperties.ID_MAPPER.put(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window_state"), WindowStateProperty.TYPE);
+		SpecialModelRenderers.ID_MAPPER.put(Identifier.fromNamespaceAndPath(WaylandCraftCommon.MOD_ID, "window"), WindowSpecialRenderer.Unbaked.MAP_CODEC);
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/render/model/WindowSpecialRenderer.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/model/WindowSpecialRenderer.java
@@ -14,7 +14,6 @@ import com.mojang.serialization.MapCodec;
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
 import dev.evvie.waylandcraft.desktop.DesktopEntry;
-import dev.evvie.waylandcraft.item.WindowItem;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.special.SpecialModelRenderer;
@@ -34,7 +33,7 @@ public class WindowSpecialRenderer implements SpecialModelRenderer<Identifier> {
 	
 	@Override
 	public Identifier extractArgument(ItemStack item) {
-		WLCToplevel toplevel = WindowItem.getToplevel(item);
+		WLCToplevel toplevel = WaylandCraft.getToplevel(item);
 		if(toplevel == null) return null;
 		
 		DesktopEntry entry = WaylandCraft.instance.xdgManager.forAppId(toplevel.appID);

--- a/src/main/java/dev/evvie/waylandcraft/render/model/WindowStateProperty.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/model/WindowStateProperty.java
@@ -24,7 +24,7 @@ public record WindowStateProperty() implements SelectItemModelProperty<WindowSta
 	@Override
 	public WindowState get(ItemStack item, ClientLevel clientLevel, LivingEntity livingEntity, int i, ItemDisplayContext itemDisplayContext) {
 		WLCToplevel toplevel = WindowItem.getToplevel(item);
-		if(toplevel == null) return WindowState.BROKEN;
+		if(toplevel == null) return WindowState.NONE;
 		
 		DesktopEntry entry = WaylandCraft.instance.xdgManager.forAppId(toplevel.appID);
 		if(entry == null) return WindowState.NONE;

--- a/src/main/java/dev/evvie/waylandcraft/render/model/WindowStateProperty.java
+++ b/src/main/java/dev/evvie/waylandcraft/render/model/WindowStateProperty.java
@@ -6,7 +6,6 @@ import com.mojang.serialization.MapCodec;
 import dev.evvie.waylandcraft.WaylandCraft;
 import dev.evvie.waylandcraft.bridge.WLCToplevel;
 import dev.evvie.waylandcraft.desktop.DesktopEntry;
-import dev.evvie.waylandcraft.item.WindowItem;
 import dev.evvie.waylandcraft.render.model.WindowStateProperty.WindowState;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.item.properties.select.SelectItemModelProperty;
@@ -23,7 +22,7 @@ public record WindowStateProperty() implements SelectItemModelProperty<WindowSta
 	
 	@Override
 	public WindowState get(ItemStack item, ClientLevel clientLevel, LivingEntity livingEntity, int i, ItemDisplayContext itemDisplayContext) {
-		WLCToplevel toplevel = WindowItem.getToplevel(item);
+		WLCToplevel toplevel = WaylandCraft.getToplevel(item);
 		if(toplevel == null) return WindowState.NONE;
 		
 		DesktopEntry entry = WaylandCraft.instance.xdgManager.forAppId(toplevel.appID);

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Field;
 
 import org.jetbrains.annotations.Nullable;
 
-import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 
 /* Settings for waylandcraft
  * 
@@ -48,7 +48,7 @@ public class WaylandCraftSettings {
 			Field field = WaylandCraftSettings.class.getDeclaredField(name);
 			field.setInt(this, value);
 		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-			WaylandCraft.LOGGER.error("Invalid setting accessed: '" + name + "' as int!");
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as int!");
 			e.printStackTrace();
 		}
 	}
@@ -58,7 +58,7 @@ public class WaylandCraftSettings {
 			Field field = WaylandCraftSettings.class.getDeclaredField(name);
 			field.setBoolean(this, value);
 		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-			WaylandCraft.LOGGER.error("Invalid setting accessed: '" + name + "' as boolean!");
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as boolean!");
 			e.printStackTrace();
 		}
 	}
@@ -69,7 +69,7 @@ public class WaylandCraftSettings {
 			Field field = WaylandCraftSettings.class.getDeclaredField(name);
 			return field.getInt(this);
 		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-			WaylandCraft.LOGGER.error("Invalid setting accessed: '" + name + "' as int!");
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as int!");
 			e.printStackTrace();
 		}
 		return null;
@@ -81,7 +81,7 @@ public class WaylandCraftSettings {
 			Field field = WaylandCraftSettings.class.getDeclaredField(name);
 			return field.getBoolean(this);
 		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-			WaylandCraft.LOGGER.error("Invalid setting accessed: '" + name + "' as boolean!");
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as boolean!");
 			e.printStackTrace();
 		}
 		return null;

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettingsManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettingsManager.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import com.google.gson.Gson;
 
 import dev.evvie.waylandcraft.WaylandCraft;
+import dev.evvie.waylandcraft.WaylandCraftCommon;
 import net.minecraft.client.Minecraft;
 
 public class WaylandCraftSettingsManager {
@@ -51,7 +52,7 @@ public class WaylandCraftSettingsManager {
 		
 		if(keymap != null) {
 			if(!wlc.bridge.setKeymapFromStr(keymap)) {
-				WaylandCraft.LOGGER.error("Failed to load keymap!");
+				WaylandCraftCommon.LOGGER.error("Failed to load keymap!");
 			}
 		}
 		
@@ -86,13 +87,13 @@ public class WaylandCraftSettingsManager {
 			int exitCode = process.waitFor();
 			if(exitCode != 0) {
 				keymap = null;
-				WaylandCraft.LOGGER.error("xkbcli exited with error " + exitCode);
+				WaylandCraftCommon.LOGGER.error("xkbcli exited with error " + exitCode);
 			}
 		} catch (IOException | InterruptedException e) {
-			WaylandCraft.LOGGER.error("xkbcli invoke failed!", e);
+			WaylandCraftCommon.LOGGER.error("xkbcli invoke failed!", e);
 		}
 		if(keymap == null) {
-			WaylandCraft.LOGGER.error("Failed to dump keymap using xkbcli");
+			WaylandCraftCommon.LOGGER.error("Failed to dump keymap using xkbcli");
 		}
 		return keymap;
 	}
@@ -107,7 +108,7 @@ public class WaylandCraftSettingsManager {
 			stream.close();
 			return keymap;
 		} catch(IOException e) {
-			WaylandCraft.LOGGER.info("Error reading keymap file!", e);
+			WaylandCraftCommon.LOGGER.info("Error reading keymap file!", e);
 			return null;
 		}
 	}

--- a/src/main/java/dev/evvie/waylandcraft/utils/CursorShape.java
+++ b/src/main/java/dev/evvie/waylandcraft/utils/CursorShape.java
@@ -1,4 +1,4 @@
-package dev.evvie.waylandcraft;
+package dev.evvie.waylandcraft.utils;
 
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/dev/evvie/waylandcraft/utils/IMyServerPlayer.java
+++ b/src/main/java/dev/evvie/waylandcraft/utils/IMyServerPlayer.java
@@ -1,0 +1,12 @@
+package dev.evvie.waylandcraft.utils;
+
+import java.util.ArrayList;
+
+public interface IMyServerPlayer {
+	
+	void setItemGiveCooldown(int cooldown);
+	int getItemGiveCooldown();
+	
+	ArrayList<Long> getAliveWindows();
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/utils/WaylandCraftUtils.java
+++ b/src/main/java/dev/evvie/waylandcraft/utils/WaylandCraftUtils.java
@@ -1,4 +1,4 @@
-package dev.evvie.waylandcraft;
+package dev.evvie.waylandcraft.utils;
 
 import org.joml.Quaternionf;
 import org.joml.Vector3f;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,11 @@
 		]
 	},
 	"mixins": [
-		"waylandcraft.mixins.json"
+		"waylandcraft.mixins.json",
+		{
+			"config": "waylandcraft.client.mixins.json",
+			"environment": "client"
+		}
 	],
 	"depends": {
 		"fabricloader": ">=0.19.2",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
 	"environment": "*",
 	"entrypoints": {
 		"main": [
-			"dev.evvie.waylandcraft.WaylandCraft"
+			"dev.evvie.waylandcraft.WaylandCraftCommon"
 		],
 		"client": [
 			"dev.evvie.waylandcraft.WaylandCraft"

--- a/src/main/resources/waylandcraft.client.mixins.json
+++ b/src/main/resources/waylandcraft.client.mixins.json
@@ -1,0 +1,29 @@
+{
+	"required": true,
+	"package": "dev.evvie.waylandcraft.mixin",
+	"compatibilityLevel": "JAVA_25",
+	"mixins": [
+		"MouseHandlerMixin",
+		"GlBackendMixin",
+		"KeyboardHandlerMixin",
+		"IMouseHandlerMixin",
+		"ItemInHandRendererMixin",
+		"IItemInHandRendererMixin",
+		"MinecraftMixin",
+		"GuiMixin",
+		"NativeImageMixin",
+		"ItemFrameRendererMixin",
+		"ItemFrameRenderStateMixin",
+		"IGlTextureMixin",
+		"IGuiGraphicsExtractor",
+		"FramerateLimitTrackerMixin",
+		"TitleScreenMixin",
+		"PauseScreenMixin"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	},
+	"overwrites": {
+		"requireAnnotations": true
+	}
+}

--- a/src/main/resources/waylandcraft.mixins.json
+++ b/src/main/resources/waylandcraft.mixins.json
@@ -1,24 +1,8 @@
 {
 	"required": true,
 	"package": "dev.evvie.waylandcraft.mixin",
-	"compatibilityLevel": "JAVA_21",
+	"compatibilityLevel": "JAVA_25",
 	"mixins": [
-		"MouseHandlerMixin",
-		"GlBackendMixin",
-		"KeyboardHandlerMixin",
-		"IMouseHandlerMixin",
-		"ItemInHandRendererMixin",
-		"IItemInHandRendererMixin",
-		"MinecraftMixin",
-		"GuiMixin",
-		"NativeImageMixin",
-		"ItemFrameRendererMixin",
-		"ItemFrameRenderStateMixin",
-		"IGlTextureMixin",
-		"IGuiGraphicsExtractor",
-		"FramerateLimitTrackerMixin",
-		"TitleScreenMixin",
-		"PauseScreenMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1

--- a/src/main/resources/waylandcraft.mixins.json
+++ b/src/main/resources/waylandcraft.mixins.json
@@ -3,6 +3,7 @@
 	"package": "dev.evvie.waylandcraft.mixin",
 	"compatibilityLevel": "JAVA_25",
 	"mixins": [
+		"ServerPlayerMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
This PR adds a separate common entry point and includes a variety of refactors to split client and server-side code and allow the mod to run on dedicated servers such that players can use their window items on supported servers. The mod is not multiplayer, so other players cannot see the world windows but players can now use their own window items on servers