### PR TITLE
Add xwayland-satellite integration

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "jni",
  "libc",
  "resvg",
+ "rustix 1.1.3",
  "shlex",
  "smithay",
  "thiserror",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,7 @@ libc = { version = "0.2.176", default-features = false }
 xkbcommon = "0.8.0"
 cosmic-freedesktop-icons = { git = "https://github.com/pop-os/freedesktop-icons.git", rev = "7a61a70" }
 freedesktop-desktop-entry = "0.8.1"
-resvg = { version = "0.47.0", default-features = false, features = ["text", "memmap-fonts"] }
+resvg = { version = "0.47.0", default-features = false, features = [ "text", "memmap-fonts" ] }
 shlex = "1.3.0"
 thiserror = "2.0"
+rustix = { version = "1.1.3", features = [ "fs", "process" ] }

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -114,6 +114,10 @@ bind_java_type! {
             sig = (instance: jlong) -> JString,
             fn = socket,
         },
+        static extern fn x11_display {
+            sig = (instance: jlong) -> JString,
+            fn = x11_display,
+        },
         static extern fn send_frame {
             sig = (surface_handle: jlong),
             fn = send_frame,
@@ -500,6 +504,20 @@ fn socket<'local>(
         .ok_or(BridgeError::OsStringToUtf8)?;
 
     Ok(JString::new(env, socket)?)
+}
+
+fn x11_display<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    instance: jlong,
+) -> Result<JString<'local>, BridgeError> {
+    let instance = jptr_to_instance!(instance, "x11Display")?;
+    if let Some(ref s) = instance.state.satellite {
+        Ok(JString::new(env, s.get_display())?)
+    }
+    else {
+        Ok(JString::null())
+    }
 }
 
 fn send_frame<'local>(

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -102,6 +102,10 @@ bind_java_type! {
             sig = (glfw_get_proc_address: jlong, egl_display: jlong) -> jlong,
             fn = init,
         },
+        static extern fn shutdown {
+            sig = (instance: jlong),
+            fn = shutdown,
+        },
         static extern fn update {
             sig = (instance: jlong),
             fn = update,
@@ -456,6 +460,21 @@ fn init<'local>(
     let ptr = Box::into_raw(instance_box);
 
     Ok(ptr.addr() as jlong)
+}
+
+fn shutdown<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    instance: jlong,
+) -> Result<(), BridgeError> {
+    // This function acquires the instance from a raw pointer again and
+    // drops it. Goes without saying that there shouldn't be any further
+    // calls into the bridge after this.
+
+    let ptr = instance as *mut WaylandCraft;
+    let _ = unsafe { Box::from_raw(ptr) };
+
+    Ok(())
 }
 
 fn update<'local>(

--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -1847,12 +1847,15 @@ fn exec_app<'local>(
     let instance = jptr_to_instance!(instance, "execApp")?;
     let app_id = app_id.try_to_string(env)?;
 
-    let env_vars = vec![
+    let mut env_vars = vec![
         ("WAYLAND_DISPLAY".into(), instance.state.socket.clone()),
         ("QT_QPA_PLATFORM".into(), "wayland".into()),
         ("ELECTRON_OZONE_PLATFORM_HINT".into(), "auto".into()),
         ("GDK_BACKEND".into(), "wayland".into()),
     ];
+    if let Some(ref s) = instance.state.satellite {
+        env_vars.push(("DISPLAY".into(), s.get_display().into()));
+    }
 
     Ok(instance.xdg.exec_app(app_id, env_vars))
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -327,9 +327,12 @@ pub(crate) fn wlc_init(
 
     let xdg = XDGSpecHelper::init();
 
-    match satellite::start_satellite(state.socket.clone()) {
+    match satellite::start_satellite(&state.socket) {
         Ok(s) => state.satellite = Some(s),
         Err(e) => eprintln!("Failed to start xwayland-satellite! Error: {e}"),
+    }
+    if let Some(ref s) = state.satellite {
+        println!("Started xwayland-satellite on display {}", s.get_display());
     }
 
     let instance = WaylandCraft {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,6 +2,7 @@ use crate::bridge::BridgeState;
 use crate::ddm::WLCDataState;
 use crate::egl::EGLHelper;
 use crate::output::WLCOutput;
+use crate::satellite::SatelliteState;
 use crate::seat::WLCSeatState;
 use crate::xdg_spec::XDGSpecHelper;
 use smithay::{
@@ -50,6 +51,7 @@ mod egl;
 mod java_types;
 mod output;
 mod process;
+mod satellite;
 mod seat;
 mod svg;
 mod utils;
@@ -77,6 +79,7 @@ pub struct WLCState {
     pub seat: WLCSeatState,
     pub data: WLCDataState,
     pub output: WLCOutput,
+    pub satellite: Option<SatelliteState>,
 }
 
 #[derive(Default)]
@@ -125,6 +128,7 @@ impl WLCState {
             seat,
             data,
             output,
+            satellite: None,
         }
     }
 }
@@ -322,6 +326,11 @@ pub(crate) fn wlc_init(
         .unwrap();
 
     let xdg = XDGSpecHelper::init();
+
+    match satellite::start_satellite(state.socket.clone()) {
+        Ok(s) => state.satellite = Some(s),
+        Err(e) => eprintln!("Failed to start xwayland-satellite! Error: {e}"),
+    }
 
     let instance = WaylandCraft {
         state,

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -331,9 +331,6 @@ pub(crate) fn wlc_init(
         Ok(s) => state.satellite = Some(s),
         Err(e) => eprintln!("Failed to start xwayland-satellite! Error: {e}"),
     }
-    if let Some(ref s) = state.satellite {
-        println!("Started xwayland-satellite on display {}", s.get_display());
-    }
 
     let instance = WaylandCraft {
         state,

--- a/native/src/satellite.rs
+++ b/native/src/satellite.rs
@@ -1,8 +1,10 @@
-use std::ffi::OsString;
+use std::ffi::OsStr;
+use std::os::unix::net::{SocketAddr, UnixListener};
+use std::os::fd::{OwnedFd, RawFd, AsRawFd};
 use std::process::{Command, Child, Stdio};
-use rustix::io::Errno;
+use rustix::io::{Errno, write, fcntl_setfd, FdFlags};
 use rustix::fs::{Access, OFlags, access, lstat, mkdir, open, unlink};
-use rustix::process::{Pid, getuid, test_kill_process};
+use rustix::process::{Pid, getuid, getpid, test_kill_process};
 use thiserror::Error;
 
 /* Small parts of this code have been adapted from niri's implementation of
@@ -14,7 +16,16 @@ use thiserror::Error;
  */
 
 pub struct SatelliteState {
-    lock_guard: PathGuard,
+    display: i32,
+    _handle: Child,
+    _lock_guard: TmpFileGuard,
+    _unix_guard: TmpFileGuard,
+}
+
+impl SatelliteState {
+    pub fn get_display(&self) -> String {
+        format!(":{0}", self.display)
+    }
 }
 
 #[derive(Error, Debug)]
@@ -33,12 +44,22 @@ pub enum SatelliteError {
     FailX11DirPermCheck(Errno),
     #[error("X11 unix directory has the wrong permissions: {0}")]
     X11DirInvalidPerms(&'static str),
+    #[error("Failed to write X11 lock file: {0}")]
+    FailWriteLockFile(Errno),
+    #[error("Failed to bind to the X11 unix socket: {0}")]
+    FailBindUnixSocket(std::io::Error),
+    #[error("Failed to clone X11 socket: {0}")]
+    FailCloneSocket(std::io::Error),
+    #[error("Failed to set socket flags via fcntl")]
+    FailSetFdFlags(Errno),
     #[error("Failed to create X11 display socket")]
     NoDisplay,
 }
 
-struct PathGuard(String);
-impl Drop for PathGuard {
+// Guard for a temporary file
+// Deletes the file when dropped
+struct TmpFileGuard(String);
+impl Drop for TmpFileGuard {
     fn drop(&mut self) {
         let _ = unlink(&self.0);
     }
@@ -122,34 +143,127 @@ fn maybe_cleanup_lockfile(path: &str) -> Result<(), ()> {
     Ok(())
 }
 
+// Attempts to acquire lock file for display number.
+// Returns Ok(None) when the lock could not be acquired
+// Returns Ok(Some(...)) when the lock was acquired successfully
+// Returns Err(...) when an error occurred during writing
+fn try_lock_display(dpy: i32) -> Result<Option<TmpFileGuard>, SatelliteError> {
+    let lock_path = format!("{TMP_UNIX_DIR}/.X{dpy}-lock");
+
+    // Cleanup lockfile if it exists but isn't used anymore
+    let _ = maybe_cleanup_lockfile(&lock_path);
+
+    // Create display lock
+    let flags =
+        OFlags::WRONLY | OFlags::CLOEXEC | OFlags::CREATE | OFlags::EXCL;
+    let lock_fd = match open(&lock_path, flags, 0o444.into()) {
+        Ok(fd) => fd,
+        Err(_) => {
+            // Lock could not be acquired
+            return Ok(None)
+        }
+    };
+    // Create guard immediately after open(...) so the lockfile is deleted when
+    // the guard is dropped.
+    let guard = TmpFileGuard(lock_path);
+
+    let data = format!("{:>10}\n", getpid().as_raw_nonzero());
+    write(&lock_fd, data.as_bytes())
+        .map_err(SatelliteError::FailWriteLockFile)?;
+    drop(lock_fd);
+
+    Ok(Some(guard))
+}
+
+struct X11Sockets {
+    unix_fd: OwnedFd,
+    unix_guard: TmpFileGuard,
+}
+
+fn try_open_sockets(dpy: i32) -> Result<X11Sockets, SatelliteError> {
+    let socket_path = format!("{X11_TMP_UNIX_DIR}/X{dpy}");
+
+    /* Create unix socket */
+    let unix_addr = SocketAddr::from_pathname(&socket_path).unwrap();
+    let unix_socket = UnixListener::bind_addr(&unix_addr)
+        .map_err(SatelliteError::FailBindUnixSocket)?;
+    // Create temp file guard now that the socket was created so it now
+    // automatically gets deleted when dropped
+    let unix_guard = TmpFileGuard(socket_path);
+    let unix_fd = OwnedFd::from(unix_socket);
+
+    Ok(X11Sockets {
+        unix_fd,
+        unix_guard,
+    })
+}
+
+fn try_invoke_xws(
+    wayland_display: &OsStr,
+    display: i32,
+    listenfds: &[RawFd]
+) -> Result<Child, SatelliteError> {
+    let mut command = Command::new(XWS_BINARY);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env("WAYLAND_DISPLAY", wayland_display)
+        .env_remove("DISPLAY")
+        .env_remove("LD_LIBRARY_PATH");
+
+    command.arg(format!(":{display}"));
+    for fd in listenfds {
+        command.arg("-listenfd").arg(fd.to_string());
+    }
+
+    command.spawn().map_err(SatelliteError::FailExecute)
+}
+
+// Copy an owned file descriptor, clear any flags (notably CLOEXEC!) and return
+// the copied file descriptor.
+//
+// Clearing the flags is important because otherwise CLOEXEC will be set and the
+// file descriptor will not be correctly passed to the child process
+// (meaning xwayland-satellite)
+fn copy_listenfd(
+    listenfd: &OwnedFd
+) -> Result<(OwnedFd, RawFd), SatelliteError> {
+    let listenfd_copy = listenfd.try_clone()
+        .map_err(SatelliteError::FailCloneSocket)?;
+    fcntl_setfd(&listenfd_copy, FdFlags::empty())
+        .map_err(SatelliteError::FailSetFdFlags)?;
+    let raw = listenfd_copy.as_raw_fd();
+    Ok((listenfd_copy, raw))
+}
+
 pub fn start_satellite(
-    wayland_display: OsString,
+    wayland_display: &OsStr,
 ) -> Result<SatelliteState, SatelliteError> {
     ensure_x11_unix_dir()?;
     test_satellite()?;
 
     for dpy in 1..=32 {
-        let socket_path = format!("{X11_TMP_UNIX_DIR}/X{dpy}");
-        let lock_path = format!("{TMP_UNIX_DIR}/.X{dpy}-lock");
-
-        // Cleanup lockfile if it exists but isn't used anymore
-        let _ = maybe_cleanup_lockfile(&lock_path);
-
-        // Create display lock
-        let flags =
-            OFlags::WRONLY | OFlags::CLOEXEC | OFlags::CREATE | OFlags::EXCL;
-        let lock_fd = match open(&lock_path, flags, 0o444.into()) {
-            Ok(fd) => fd,
-            Err(_) => continue
+        let lock_guard = match try_lock_display(dpy)? {
+            Some(g) => g,
+            None => continue
         };
 
-        // Create guard so the lockfile is deleted when no longer used
-        let lock_guard = PathGuard(lock_path);
+        let X11Sockets { unix_fd, unix_guard } = try_open_sockets(dpy)?;
+        let (unix_fd_copy, unix_fd_raw) = copy_listenfd(&unix_fd)?;
 
-        println!("Found open display :{dpy}!");
+        let handle = try_invoke_xws(wayland_display, dpy, &[
+            unix_fd_raw,
+        ])?;
+
+        // Only drop file descriptor after passing it to xwayland-satellite
+        drop(unix_fd_copy);
 
         return Ok(SatelliteState {
-            lock_guard,
+            display: dpy,
+            _handle: handle,
+            _lock_guard: lock_guard,
+            _unix_guard: unix_guard,
         });
     }
 

--- a/native/src/satellite.rs
+++ b/native/src/satellite.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 use std::os::unix::net::{SocketAddr, UnixListener};
+use std::os::linux::net::SocketAddrExt;
 use std::os::fd::{OwnedFd, RawFd, AsRawFd};
 use std::process::{Command, Child, Stdio};
 use rustix::io::{Errno, write, fcntl_setfd, FdFlags};
@@ -48,6 +49,8 @@ pub enum SatelliteError {
     FailWriteLockFile(Errno),
     #[error("Failed to bind to the X11 unix socket: {0}")]
     FailBindUnixSocket(std::io::Error),
+    #[error("Failed to bind to the X11 abstract socket: {0}")]
+    FailBindAbstractSocket(std::io::Error),
     #[error("Failed to clone X11 socket: {0}")]
     FailCloneSocket(std::io::Error),
     #[error("Failed to set socket flags via fcntl")]
@@ -178,12 +181,20 @@ fn try_lock_display(dpy: i32) -> Result<Option<TmpFileGuard>, SatelliteError> {
 struct X11Sockets {
     unix_fd: OwnedFd,
     unix_guard: TmpFileGuard,
+    abstract_fd: OwnedFd,
 }
 
 fn try_open_sockets(dpy: i32) -> Result<X11Sockets, SatelliteError> {
     let socket_path = format!("{X11_TMP_UNIX_DIR}/X{dpy}");
 
+    /* Create abstract socket */
+    let abstract_addr = SocketAddr::from_abstract_name(&socket_path).unwrap();
+    let abstract_socket = UnixListener::bind_addr(&abstract_addr)
+        .map_err(SatelliteError::FailBindAbstractSocket)?;
+    let abstract_fd = OwnedFd::from(abstract_socket);
+
     /* Create unix socket */
+    let _ = unlink(&socket_path); // Delete potential existing socket
     let unix_addr = SocketAddr::from_pathname(&socket_path).unwrap();
     let unix_socket = UnixListener::bind_addr(&unix_addr)
         .map_err(SatelliteError::FailBindUnixSocket)?;
@@ -195,6 +206,7 @@ fn try_open_sockets(dpy: i32) -> Result<X11Sockets, SatelliteError> {
     Ok(X11Sockets {
         unix_fd,
         unix_guard,
+        abstract_fd,
     })
 }
 
@@ -249,21 +261,24 @@ pub fn start_satellite(
             None => continue
         };
 
-        let X11Sockets { unix_fd, unix_guard } = try_open_sockets(dpy)?;
-        let (unix_fd_copy, unix_fd_raw) = copy_listenfd(&unix_fd)?;
+        let sockets = try_open_sockets(dpy)?;
+        let (unix_fd_copy, unix_fd_raw) = copy_listenfd(&sockets.unix_fd)?;
+        let (abs_fd_copy, abs_fd_raw) = copy_listenfd(&sockets.abstract_fd)?;
 
         let handle = try_invoke_xws(wayland_display, dpy, &[
             unix_fd_raw,
+            abs_fd_raw,
         ])?;
 
         // Only drop file descriptor after passing it to xwayland-satellite
         drop(unix_fd_copy);
+        drop(abs_fd_copy);
 
         return Ok(SatelliteState {
             display: dpy,
             _handle: handle,
             _lock_guard: lock_guard,
-            _unix_guard: unix_guard,
+            _unix_guard: sockets.unix_guard,
         });
     }
 

--- a/native/src/satellite.rs
+++ b/native/src/satellite.rs
@@ -1,0 +1,157 @@
+use std::ffi::OsString;
+use std::process::{Command, Child, Stdio};
+use rustix::io::Errno;
+use rustix::fs::{Access, OFlags, access, lstat, mkdir, open, unlink};
+use rustix::process::{Pid, getuid, test_kill_process};
+use thiserror::Error;
+
+/* Small parts of this code have been adapted from niri's implementation of
+ * xwayland-satellite integration, as well as from Mutter's XWayland code
+ * (which niri also borrowed from).
+ *
+ * niri (https://github.com/niri-wm/niri) is GPLv3 software.
+ * Mutter (https://gitlab.gnome.org/GNOME/mutter) is GPLv2-or-later software.
+ */
+
+pub struct SatelliteState {
+    lock_guard: PathGuard,
+}
+
+#[derive(Error, Debug)]
+pub enum SatelliteError {
+    #[error("Failed to execute xwayland-satellite command: {0}")]
+    FailExecute(std::io::Error),
+    #[error("xwayland-satellite was unexpectedly terminated by a signal")]
+    Terminated,
+    #[error("xwayland-satellite does not support -listenfd. Exit status: {0}")]
+    NoListenFD(i32),
+    #[error("Failed to create X11 directory. Error: {0}")]
+    X11DirCreate(Errno),
+    #[error("Failed checking tmp directory permissions. Error: {0}")]
+    FailTmpDirPermCheck(Errno),
+    #[error("Failed checking X11 directory permissions. Error: {0}")]
+    FailX11DirPermCheck(Errno),
+    #[error("X11 unix directory has the wrong permissions: {0}")]
+    X11DirInvalidPerms(&'static str),
+    #[error("Failed to create X11 display socket")]
+    NoDisplay,
+}
+
+struct PathGuard(String);
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        let _ = unlink(&self.0);
+    }
+}
+
+const XWS_BINARY: &str = "xwayland-satellite";
+const TMP_UNIX_DIR: &str = "/tmp";
+const X11_TMP_UNIX_DIR: &str = "/tmp/.X11-unix";
+
+fn test_satellite() -> Result<(), SatelliteError> {
+    let mut command = Command::new(XWS_BINARY);
+    command
+        .arg("--test-listenfd-support")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_remove("DISPLAY")
+        .env_remove("WAYLAND_DISPLAY")
+        .env_remove("LD_LIBRARY_PATH");
+
+    let status = command.status().map_err(SatelliteError::FailExecute)?;
+    if status.success() {
+        Ok(())
+    } else if let Some(code) = status.code() {
+        Err(SatelliteError::NoListenFD(code))
+    } else {
+        Err(SatelliteError::Terminated)
+    }
+}
+
+// From Mutter (src/wayland/meta-xwayland.c, commit 36ca36b4).
+fn ensure_x11_unix_dir() -> Result<(), SatelliteError> {
+    match mkdir(X11_TMP_UNIX_DIR, 0o1777.into()) {
+        Ok(()) => Ok(()),
+        Err(Errno::EXIST) => {
+            check_x11_unix_perms()?;
+            Ok(())
+        }
+        Err(err) => Err(SatelliteError::X11DirCreate(err)),
+    }
+}
+
+// From Mutter (src/wayland/meta-xwayland.c, commit 36ca36b4).
+fn check_x11_unix_perms() -> Result<(), SatelliteError> {
+    // Query status of the /tmp and /tmp/.X11-unix directories
+    let x11_tmp =
+        lstat(X11_TMP_UNIX_DIR).map_err(SatelliteError::FailX11DirPermCheck)?;
+    let tmp =
+        lstat(TMP_UNIX_DIR).map_err(SatelliteError::FailTmpDirPermCheck)?;
+
+    // The owner of the .X11-unix dir should either be the owner of the tmp dir
+    // or the current user for security reasons.
+    if x11_tmp.st_uid != tmp.st_uid && x11_tmp.st_uid != getuid().as_raw() {
+        return Err(SatelliteError::X11DirInvalidPerms("wrong ownership"));
+    }
+
+    // The .X11-unix dir has to be writable
+    access(X11_TMP_UNIX_DIR, Access::WRITE_OK)
+        .map_err(|_| SatelliteError::X11DirInvalidPerms("not writeable"))?;
+
+    // And it should have the sticky bit set
+    if (x11_tmp.st_mode & 0o1000) != 0o1000 {
+        return Err(SatelliteError::X11DirInvalidPerms("no sticky bit"));
+    }
+
+    Ok(())
+}
+
+fn maybe_cleanup_lockfile(path: &str) -> Result<(), ()> {
+    let data = std::fs::read_to_string(path).map_err(|_| ())?;
+    let pid = data.trim().parse::<u32>().map_err(|_| ())?;
+    let pid = i32::try_from(pid).map_err(|_| ())?;
+    let pid = Pid::from_raw(pid).ok_or(())?;
+
+    if matches!(test_kill_process(pid), Err(Errno::SRCH)) {
+        // No process matches the pid in the lockfile, delete it
+        let _ = unlink(path);
+        return Ok(());
+    }
+
+    Ok(())
+}
+
+pub fn start_satellite(
+    wayland_display: OsString,
+) -> Result<SatelliteState, SatelliteError> {
+    ensure_x11_unix_dir()?;
+    test_satellite()?;
+
+    for dpy in 1..=32 {
+        let socket_path = format!("{X11_TMP_UNIX_DIR}/X{dpy}");
+        let lock_path = format!("{TMP_UNIX_DIR}/.X{dpy}-lock");
+
+        // Cleanup lockfile if it exists but isn't used anymore
+        let _ = maybe_cleanup_lockfile(&lock_path);
+
+        // Create display lock
+        let flags =
+            OFlags::WRONLY | OFlags::CLOEXEC | OFlags::CREATE | OFlags::EXCL;
+        let lock_fd = match open(&lock_path, flags, 0o444.into()) {
+            Ok(fd) => fd,
+            Err(_) => continue
+        };
+
+        // Create guard so the lockfile is deleted when no longer used
+        let lock_guard = PathGuard(lock_path);
+
+        println!("Found open display :{dpy}!");
+
+        return Ok(SatelliteState {
+            lock_guard,
+        });
+    }
+
+    Err(SatelliteError::NoDisplay)
+}

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -70,6 +70,7 @@ public class WaylandCraft implements ClientModInitializer {
 	
 	public WaylandCraftBridge bridge = null;
 	public String waylandSocket = "";
+	public @Nullable String x11Display = null;
 	
 	public ArrayList<WindowDisplay> displays = new ArrayList<WindowDisplay>();
 	
@@ -134,10 +135,12 @@ public class WaylandCraft implements ClientModInitializer {
 		if(bridge == null) {
 			bridge = WaylandCraftBridge.start();
 			waylandSocket = bridge.getSocket();
+			x11Display = bridge.getX11Display();
 			xdgManager = new XDGDesktopManager(this);
 			settingsManager = new WaylandCraftSettingsManager(this);
 			
-			WaylandCraftCommon.LOGGER.info("Server started on " + waylandSocket);
+			WaylandCraftCommon.LOGGER.info("Wayland server started on " + waylandSocket);
+			WaylandCraftCommon.LOGGER.info("Xwayland started on " + x11Display);
 		}
 		bridge.update();
 	}
@@ -256,6 +259,7 @@ public class WaylandCraft implements ClientModInitializer {
 	
 	private void onClientJoin(ClientPacketListener listener, PacketSender sender, Minecraft minecraft) {
 		minecraft.getChatListener().handleSystemMessage(Component.literal("Wayland compositor running on " + waylandSocket), false);
+		if(x11Display != null) minecraft.getChatListener().handleSystemMessage(Component.literal("xwayland-satellite running on " + x11Display), false);
 		itemManager.giveItemsIfMissing(bridge.getMappedToplevels());
 	}
 	

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -113,7 +113,17 @@ public class WaylandCraftBridge {
 		}
 		
 		long handle = init(GLFW.Functions.GetProcAddress, eglDisplay);
-		return new WaylandCraftBridge(handle);
+		WaylandCraftBridge bridge = new WaylandCraftBridge(handle);
+		
+		// Add shutdown thread to clean up resources on normal exit
+		Runtime.getRuntime().addShutdownHook(new Thread(bridge::shutdownHook));
+		
+		return bridge;
+	}
+	
+	private void shutdownHook() {
+		shutdown(instance);
+		instance = 0;
 	}
 	
 	protected WLCToplevel getOrCreateToplevel(long topLevelHandle) {
@@ -678,6 +688,7 @@ public class WaylandCraftBridge {
 	public static record ResizeRequest(int serial, int edges) {}
 	
 	private static native long init(long glfwGetProcAddress, long eglDisplay);
+	private static native void shutdown(long instance);
 	private static native void update(long instance);
 	private static native String socket(long instance);
 	private static native void sendFrame(long surfaceHandle);

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -490,6 +490,10 @@ public class WaylandCraftBridge {
 		return socket(this.instance);
 	}
 	
+	public @Nullable String getX11Display() {
+		return x11Display(this.instance);
+	}
+	
 	public boolean inputRegionContains(WLCSurface surface, double x, double y) {
 		return checkInputRegion(surface.getHandle(), x, y);
 	}
@@ -691,6 +695,7 @@ public class WaylandCraftBridge {
 	private static native void shutdown(long instance);
 	private static native void update(long instance);
 	private static native String socket(long instance);
+	private static native String x11Display(long instance);
 	private static native void sendFrame(long surfaceHandle);
 	
 	private static native void updateSurfaceData(long instance, WLCSurface surface);


### PR DESCRIPTION
This PR implements xwayland-satellite and therefore also Xwayland integration. When the binary is installed and in PATH, the compositor starts it automatically, including configuring the necessary sockets. Clients are directly given the right DISPLAY variable. This should add proper support without annoying setups for X11 clients.