### PR TITLE
Add support for directly launching terminal apps

### DIFF
--- a/native/src/bridge.rs
+++ b/native/src/bridge.rs
@@ -340,6 +340,10 @@ bind_java_type! {
             sig = (instance: jlong, app_id: JString) -> jboolean,
             fn = exec_app,
         },
+        static extern fn set_preferred_terminal {
+            sig = (instance: jlong, cmd: JString),
+            fn = set_preferred_terminal,
+        },
         static extern fn set_keymap_default {
             sig = (instance: jlong),
             fn = set_keymap_default,
@@ -1876,6 +1880,20 @@ fn exec_app<'local>(
     }
 
     Ok(instance.xdg.exec_app(app_id, env_vars))
+}
+
+fn set_preferred_terminal<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    instance: jlong,
+    cmd: JString<'local>,
+) -> Result<(), BridgeError> {
+    let instance = jptr_to_instance!(instance, "setPreferredTerminal")?;
+    let cmd = cmd.try_to_string(env)?;
+
+    instance.xdg.set_preferred_terminal(cmd);
+
+    Ok(())
 }
 
 fn set_keymap_default<'local>(

--- a/native/src/process.rs
+++ b/native/src/process.rs
@@ -1,11 +1,14 @@
 use std::ffi::OsString;
 use std::process::{Command, Stdio};
 
-pub fn spawn(
+pub fn spawn<A>(
     cmd: String,
-    args: Vec<String>,
+    args: A,
     env: Vec<(OsString, OsString)>,
-) -> Result<(), ()> {
+) -> Result<(), ()>
+where
+    A: IntoIterator<Item = String>
+{
     let mut command = Command::new(cmd);
     command
         .args(args)

--- a/native/src/xdg_spec.rs
+++ b/native/src/xdg_spec.rs
@@ -4,12 +4,14 @@ use freedesktop_desktop_entry::{
     DesktopEntry, desktop_entries, find_app_by_id, get_languages_from_env,
     unicase::Ascii,
 };
+use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub struct XDGSpecHelper {
     locales: Vec<String>,
     entries: Vec<DesktopEntry>,
+    preferred_terminal: String,
 }
 
 pub struct RawDesktopEntry {
@@ -30,7 +32,15 @@ impl XDGSpecHelper {
         let locales = get_languages_from_env();
         let entries = desktop_entries(&locales);
 
-        XDGSpecHelper { locales, entries }
+        XDGSpecHelper {
+            locales,
+            entries,
+            preferred_terminal: String::new(),
+        }
+    }
+
+    pub fn set_preferred_terminal(&mut self, cmd: String) {
+        self.preferred_terminal = cmd;
     }
 
     fn to_raw(&self, entry: &DesktopEntry) -> RawDesktopEntry {
@@ -119,13 +129,25 @@ impl XDGSpecHelper {
     ) -> Option<()> {
         let entry = find_app_by_id(&self.entries, Ascii::new(&app_id))?;
         let exec = entry.exec()?;
-        let mut args = split_exec(exec).ok()?;
+        let mut exec = VecDeque::from(split_exec(exec).ok()?);
 
-        if args.is_empty() {
+        if exec.is_empty() {
             return None;
         }
 
-        let cmd = args.remove(0);
+        if entry.terminal() {
+            if self.preferred_terminal.is_empty() { return None }
+            exec.push_front("-e".into());
+            exec.push_front(self.preferred_terminal.clone());
+        }
+
+        // Split off the first element. That's the executable, everything else
+        // is arguments.
+        let cmd = exec.pop_front().unwrap();
+        let args = exec;
+
+        //println!("Executing {cmd} with {:?}", args);
+
         spawn(cmd, args, env).ok()?;
 
         Some(())

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -148,7 +148,7 @@ public class WaylandCraft implements ClientModInitializer {
 	
 	private void registerSettingsResponders() {
 		settingsManager.registerResponder(WaylandCraftSettings.TERMINAL_CHOICE, (value) -> {
-			WaylandCraftCommon.LOGGER.info("TERMINAL: " + value);
+			bridge.setPreferredTerminal((String) value);
 		});
 	}
 	

--- a/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
+++ b/src/main/java/dev/evvie/waylandcraft/WaylandCraft.java
@@ -138,11 +138,18 @@ public class WaylandCraft implements ClientModInitializer {
 			x11Display = bridge.getX11Display();
 			xdgManager = new XDGDesktopManager(this);
 			settingsManager = new WaylandCraftSettingsManager(this);
+			registerSettingsResponders();
 			
 			WaylandCraftCommon.LOGGER.info("Wayland server started on " + waylandSocket);
 			WaylandCraftCommon.LOGGER.info("Xwayland started on " + x11Display);
 		}
 		bridge.update();
+	}
+	
+	private void registerSettingsResponders() {
+		settingsManager.registerResponder(WaylandCraftSettings.TERMINAL_CHOICE, (value) -> {
+			WaylandCraftCommon.LOGGER.info("TERMINAL: " + value);
+		});
 	}
 	
 	public void renderWorld(LevelRenderContext ctx) {

--- a/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
+++ b/src/main/java/dev/evvie/waylandcraft/bridge/WaylandCraftBridge.java
@@ -656,6 +656,10 @@ public class WaylandCraftBridge {
 		return execApp(instance, appId);
 	}
 	
+	public void setPreferredTerminal(String cmd) {
+		setPreferredTerminal(instance, cmd);
+	}
+	
 	public void setKeymapDefault() {
 		setKeymapDefault(instance);
 	}
@@ -811,6 +815,7 @@ public class WaylandCraftBridge {
 	private static native boolean renderSVG(String path, int width, int height, long bufferPtr);
 	
 	private static native boolean execApp(long instance, String appId);
+	private static native void setPreferredTerminal(long instance, String cmd);
 	
 	private static native void setKeymapDefault(long instance);
 	private static native String exportKeymap(long instance);

--- a/src/main/java/dev/evvie/waylandcraft/gui/SettingsWidget.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/SettingsWidget.java
@@ -8,9 +8,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.MouseButtonInfo;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
@@ -44,6 +47,11 @@ public class SettingsWidget extends AbstractWidget {
 		return new SettingsWidget(instance, control, message);
 	}
 	
+	public static SettingsWidget createTextWidget(WaylandCraft instance, String settingName, Component message) {
+		TextControlElement control = new TextControlElement(instance, settingName);
+		return new SettingsWidget(instance, control, message);
+	}
+	
 	@Override
 	protected void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a) {
 		Font font = Minecraft.getInstance().font;
@@ -73,12 +81,16 @@ public class SettingsWidget extends AbstractWidget {
 		control.extractControlElement(graphics, mouseX, mouseY, a);
 	}
 	
+	public void saveValue() {
+		control.saveValue();
+	}
+	
 	@Override
 	public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
 		if(!this.isActive()) return false;
 		if(!isMouseOver(event.x(), event.y())) return false;
 		
-		if(!doubleClick) control.onClick((int) event.x(), (int) event.y());
+		if(!doubleClick) control.onClick((int) event.x(), (int) event.y(), event.buttonInfo());
 		else control.onDoubleClick();
 		return true;
 	}
@@ -93,6 +105,12 @@ public class SettingsWidget extends AbstractWidget {
 	public boolean keyReleased(KeyEvent event) {
 		if(!this.isActive()) return false;
 		return control.onKeyReleased(event);
+	}
+	
+	@Override
+	public boolean charTyped(CharacterEvent event) {
+		if(!this.isActive()) return false;
+		return control.onCharTyped(event);
 	}
 	
 	@Override
@@ -151,7 +169,8 @@ public class SettingsWidget extends AbstractWidget {
 		}
 		
 		public abstract void extractControlElement(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a);
-		public void onClick(int mouseX, int mouseY) {}
+		public abstract void saveValue();
+		public void onClick(int mouseX, int mouseY, MouseButtonInfo buttonInfo) {}
 		public void onDoubleClick() {}
 		public void onDrag() {}
 		
@@ -164,6 +183,10 @@ public class SettingsWidget extends AbstractWidget {
 		}
 		
 		public boolean onKeyReleased(KeyEvent event) {
+			return false;
+		}
+		
+		public boolean onCharTyped(CharacterEvent event) {
 			return false;
 		}
 		
@@ -181,6 +204,11 @@ public class SettingsWidget extends AbstractWidget {
 		
 		private void setValue(boolean value) {
 			wlc.settingsManager.setBooleanSetting(settingName, value);
+		}
+		
+		@Override
+		public void saveValue() {
+			// Left blank. This widget automatically sets the value on click
 		}
 		
 		private void toggle() {
@@ -204,7 +232,7 @@ public class SettingsWidget extends AbstractWidget {
 		}
 		
 		@Override
-		public void onClick(int mouseX, int mouseY) {
+		public void onClick(int mouseX, int mouseY, MouseButtonInfo buttonInfo) {
 			if(isInside(mouseX, mouseY)) toggle();
 		}
 		
@@ -269,6 +297,11 @@ public class SettingsWidget extends AbstractWidget {
 		}
 		
 		@Override
+		public void saveValue() {
+			stopEntry();
+		}
+		
+		@Override
 		public void setFocused(boolean focused) {
 			if(!focused && isFocused()) {
 				// Focus lost
@@ -310,6 +343,77 @@ public class SettingsWidget extends AbstractWidget {
 				return true;
 			}
 			return false;
+		}
+		
+	}
+	
+	public static class TextControlElement extends ControlElement {
+		
+		private EditBox editBox;
+		
+		public TextControlElement(WaylandCraft wlc, String settingName) {
+			super(wlc, settingName);
+			
+			editBox = new EditBox(Minecraft.getInstance().font, getWidth(), getHeight(), Component.literal(settingName));
+			editBox.insertText(getSavedValue());
+			editBox.moveCursorTo(0, false);
+		}
+		
+		private String getSavedValue() {
+			return wlc.settingsManager.getTextSetting(settingName);
+		}
+		
+		@Override
+		public void setPosSize(int x, int y, int width, int height) {
+			super.setPosSize(x, y, width, height);
+			editBox.setRectangle(width, height, x, y);
+		}
+		
+		@Override
+		public void extractControlElement(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a) {
+			editBox.extractRenderState(graphics, mouseX, mouseY, a);
+		}
+		
+		@Override
+		public void saveValue() {
+			wlc.settingsManager.setTextSetting(settingName, editBox.getValue());
+		}
+		
+		@Override
+		public void onClick(int mouseX, int mouseY, MouseButtonInfo buttonInfo) {
+			super.onClick(mouseX, mouseY, buttonInfo);
+			editBox.onClick(new MouseButtonEvent(mouseX, mouseY, buttonInfo), false);
+		}
+		
+		@Override
+		public void setFocused(boolean focused) {
+			if(!focused && isFocused()) {
+				// Focus lost
+				saveValue();
+			}
+			
+			editBox.setFocused(focused);
+			super.setFocused(focused);
+		}
+		
+		@Override
+		public boolean onKeyPressed(KeyEvent event) {
+			if(event.key() == GLFW.GLFW_KEY_ENTER) {
+				saveValue();
+				return true;
+			}
+			
+			return editBox.keyPressed(event);
+		}
+		
+		@Override
+		public boolean onKeyReleased(KeyEvent event) {
+			return editBox.keyReleased(event);
+		}
+		
+		@Override
+		public boolean onCharTyped(CharacterEvent event) {
+			return editBox.charTyped(event);
 		}
 		
 	}

--- a/src/main/java/dev/evvie/waylandcraft/gui/WaylandCraftSettingsScreen.java
+++ b/src/main/java/dev/evvie/waylandcraft/gui/WaylandCraftSettingsScreen.java
@@ -47,6 +47,13 @@ public class WaylandCraftSettingsScreen extends Screen {
 	}
 	
 	@Override
+	public void removed() {
+		for(SettingsWidget widget : settingsWidgets) {
+			widget.saveValue();
+		}
+	}
+	
+	@Override
 	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a) {
 		super.extractRenderState(graphics, mouseX, mouseY, a);
 	}
@@ -67,12 +74,18 @@ public class WaylandCraftSettingsScreen extends Screen {
 		settingsWidgets.add(widget);
 	}
 	
+	public void createTextSettingsWidget(String settingName, Component message) {
+		SettingsWidget widget = SettingsWidget.createTextWidget(wlc, settingName, message);
+		settingsWidgets.add(widget);
+	}
+	
 	private void createSettings() {
 		settingsWidgets.clear();
 		
 		createIntSettingsWidget(WaylandCraftSettings.PIXELS_PER_BLOCK, Component.literal("Window display pixels per block"));
 		createBooleanSettingsWidget(WaylandCraftSettings.WINDOW_ANTIALIASING, Component.literal("Window in world antialiasing"));
 		createBooleanSettingsWidget(WaylandCraftSettings.FOCUS_ON_HOVER, Component.literal("Focus windows when hovered"));
+		createTextSettingsWidget(WaylandCraftSettings.TERMINAL_CHOICE, Component.literal("Default terminal"));
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/settings/ISettingResponder.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/ISettingResponder.java
@@ -1,0 +1,19 @@
+package dev.evvie.waylandcraft.settings;
+
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+public interface ISettingResponder {
+	
+	/**
+	 * Called when the waylandcraft setting has changed
+	 * 
+	 * This allows synchronization of settings state across the compositor. Responders are immediately
+	 * called on the observed setting when first registered. The responder may be fired multiple times
+	 * on the same value, even if it didn't change.
+	 * 
+	 * @param value the current value. Can safely be cast to the expected type
+	 */
+	void onChangeSetting(@NotNull Object value);
+	
+}

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
@@ -21,11 +21,13 @@ public class WaylandCraftSettings {
 	int pixelsPerBlock = 500;
 	boolean windowAntialiasing = false;
 	boolean focusOnHover = false;
+	String terminalChoice = "";
 	
 	/* This is where the field names go to avoid typos */
 	public static final String PIXELS_PER_BLOCK = "pixelsPerBlock";
 	public static final String WINDOW_ANTIALIASING = "windowAntialiasing";
 	public static final String FOCUS_ON_HOVER = "focusOnHover";
+	public static final String TERMINAL_CHOICE = "terminalChoice";
 	
 	/* This is where the getters go */
 	
@@ -39,6 +41,10 @@ public class WaylandCraftSettings {
 	
 	public boolean getFocusOnHover() {
 		return focusOnHover;
+	}
+	
+	public String getTerminalChoice() {
+		return terminalChoice;
 	}
 	
 	/* Methods to modifiy settings by name */
@@ -63,6 +69,16 @@ public class WaylandCraftSettings {
 		}
 	}
 	
+	protected void setTextSetting(String name, String value) {
+		try {
+			Field field = WaylandCraftSettings.class.getDeclaredField(name);
+			field.set(this, value);
+		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as text!");
+			e.printStackTrace();
+		}
+	}
+	
 	// Get int setting. Returns null only when setting was not found.
 	protected @Nullable Integer getIntSetting(String name) {
 		try {
@@ -82,6 +98,18 @@ public class WaylandCraftSettings {
 			return field.getBoolean(this);
 		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
 			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as boolean!");
+			e.printStackTrace();
+		}
+		return null;
+	}
+	
+	// Get text setting. Returns null only when setting was not found.
+	protected @Nullable String getTextSetting(String name) {
+		try {
+			Field field = WaylandCraftSettings.class.getDeclaredField(name);
+			return (String) field.get(this);
+		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as text!");
 			e.printStackTrace();
 		}
 		return null;

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettings.java
@@ -29,6 +29,13 @@ public class WaylandCraftSettings {
 	public static final String FOCUS_ON_HOVER = "focusOnHover";
 	public static final String TERMINAL_CHOICE = "terminalChoice";
 	
+	public static final String[] SETTINGS = new String[] {
+			PIXELS_PER_BLOCK,
+			WINDOW_ANTIALIASING,
+			FOCUS_ON_HOVER,
+			TERMINAL_CHOICE
+	};
+	
 	/* This is where the getters go */
 	
 	public int getPixelsPerBlock() {
@@ -77,6 +84,17 @@ public class WaylandCraftSettings {
 			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "' as text!");
 			e.printStackTrace();
 		}
+	}
+	
+	protected @Nullable Object getSettingAnyType(String name) {
+		try {
+			Field field = WaylandCraftSettings.class.getDeclaredField(name);
+			return field.get(this);
+		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+			WaylandCraftCommon.LOGGER.error("Invalid setting accessed: '" + name + "'!");
+			e.printStackTrace();
+		}
+		return null;
 	}
 	
 	// Get int setting. Returns null only when setting was not found.

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettingsManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettingsManager.java
@@ -142,6 +142,12 @@ public class WaylandCraftSettingsManager {
 		writeSettings();
 	}
 	
+	// Set a text setting and write it to file
+	public void setTextSetting(String name, String value) {
+		wlc.settings.setTextSetting(name, value);
+		writeSettings();
+	}
+	
 	// Get an int setting
 	public int getIntSetting(String name) {
 		return wlc.settings.getIntSetting(name);
@@ -150,6 +156,11 @@ public class WaylandCraftSettingsManager {
 	// Set a boolean setting
 	public boolean getBooleanSetting(String name) {
 		return wlc.settings.getBooleanSetting(name);
+	}
+	
+	// Set a text setting
+	public String getTextSetting(String name) {
+		return wlc.settings.getTextSetting(name);
 	}
 	
 }

--- a/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettingsManager.java
+++ b/src/main/java/dev/evvie/waylandcraft/settings/WaylandCraftSettingsManager.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 
 import com.google.gson.Gson;
 
@@ -20,6 +21,8 @@ public class WaylandCraftSettingsManager {
 	private File settingsDir;
 	private File keymapFile;
 	private File settingsFile;
+	
+	private ArrayList<SettingResponder> responders = new ArrayList<SettingResponder>();
 	
 	public WaylandCraftSettingsManager(WaylandCraft wlc) {
 		this.wlc = wlc;
@@ -70,10 +73,13 @@ public class WaylandCraftSettingsManager {
 		if(createSettings) {
 			// Create default settings
 			wlc.settings = new WaylandCraftSettings();
-			writeSettings();
+		}
+		else {
+			readSettings();
 		}
 		
-		readSettings();
+		// Ensure the current settings format is written to disk (i.e. when the settings change across versions)
+		writeSettings();
 	}
 	
 	private String tryReadKeymapFromSystem() {
@@ -130,21 +136,41 @@ public class WaylandCraftSettingsManager {
 		}
 	}
 	
+	public void registerResponder(String setting, ISettingResponder responder) {
+		if(responders.stream().anyMatch((r) -> r.impl == responder)) return;
+		
+		responders.add(new SettingResponder(setting, responder));
+		responder.onChangeSetting(wlc.settings.getSettingAnyType(setting));
+	}
+	
+	private void updateResponders(String setting, Object value) {
+		for(SettingResponder r : responders) {
+			r.maybeFire(setting, value);
+		}
+	}
+	
+	public void unregisterResponder(ISettingResponder responder) {
+		responders.removeIf((r) -> r.impl == responder);
+	}
+	
 	// Set an int setting and write it to file
 	public void setIntSetting(String name, int value) {
 		wlc.settings.setIntSetting(name, value);
+		updateResponders(name, (Integer) value);
 		writeSettings();
 	}
 	
 	// Set a boolean setting and write it to file
 	public void setBooleanSetting(String name, boolean value) {
 		wlc.settings.setBooleanSetting(name, value);
+		updateResponders(name, (Boolean) value);
 		writeSettings();
 	}
 	
 	// Set a text setting and write it to file
 	public void setTextSetting(String name, String value) {
 		wlc.settings.setTextSetting(name, value);
+		updateResponders(name, value);
 		writeSettings();
 	}
 	
@@ -161,6 +187,24 @@ public class WaylandCraftSettingsManager {
 	// Set a text setting
 	public String getTextSetting(String name) {
 		return wlc.settings.getTextSetting(name);
+	}
+	
+	private static class SettingResponder {
+		
+		public final String settingName;
+		public final ISettingResponder impl;
+		
+		public SettingResponder(String settingName, ISettingResponder impl) {
+			this.settingName = settingName;
+			this.impl = impl;
+		}
+		
+		protected void maybeFire(String setting, Object value) {
+			if(setting.equals(this.settingName)) {
+				impl.onChangeSetting(value);
+			}
+		}
+		
 	}
 	
 }


### PR DESCRIPTION
Desktop entries with the `Terminal=true` field can now be launched in a terminal.
Which terminal is chosen has to be configured in the settings menu. The settings and menu have been expanded to allow for text fields